### PR TITLE
Feat: Lock aos process

### DIFF
--- a/process/process.lua
+++ b/process/process.lua
@@ -144,6 +144,22 @@ function process.handle(msg, ao)
       return 'installing manpage'
     end
 
+    function Lock()
+      LockedAt = msg["Block-Height"]
+      return 'Process is being locked... It can be unlocked until block ' .. (LockedAt + 5) .. '.'
+    end
+
+    -- to make sure the user can revert an unintentional locking,
+    -- they're allowed to Unlock() in the next 5 blocks
+    function Unlock()
+      if not LockedAt or LockedAt + 5 < msg["Block-Height"] then
+        return
+      end
+
+      LockedAt = nil
+      return 'process unlocked'
+    end
+
     -- exec expression
     local expr = msg.Data
 

--- a/process/process.lua
+++ b/process/process.lua
@@ -160,6 +160,15 @@ function process.handle(msg, ao)
       return 'process unlocked'
     end
 
+    -- return if the process has been locked
+    if LockedAt and LockedAt + 5 < msg["Block-Height"] then
+      return ao.result({ Output = { data = {
+        json = "undefined",
+        output = "process locked",
+        prompt = Prompt()
+      } } })
+    end
+
     -- exec expression
     local expr = msg.Data
 


### PR DESCRIPTION
The lock feature allows the user to call the `Lock()` global function, which will prevent any future `Eval` interactions with the process. This is useful for mature processes that are stable and will not change, so the community expects them to have immutable code.

As a preventative measure, if the user accidentally calls `Lock()`, they can unlock the process in the next 5 blocks with `Unlock()`.