### PR TITLE
New handler utility functions

### DIFF
--- a/process/handlers-utils.lua
+++ b/process/handlers-utils.lua
@@ -11,6 +11,21 @@ function _utils.hasMatchingTag(name, value)
   end
 end
 
+function _utils.hasMatchingTagOf(name, values)
+  assert(type(name) == 'string' and type(values) == 'table', 'invalid arguments: (name : string, values : string[])')
+  return function (msg)
+    for _, value in ipairs(values) do
+      local patternResult = Handlers.utils.hasMatchingTag(name, value)(msg)
+
+      if patternResult ~= 0 then
+        return patternResult
+      end
+    end
+
+    return 0
+  end
+end
+
 function _utils.hasMatchingData(value)
   assert(type(value) == 'string', 'invalid arguments: (value : string)')
   return function (msg)

--- a/process/handlers-utils.lua
+++ b/process/handlers-utils.lua
@@ -44,5 +44,16 @@ function _utils.reply(input)
   end
 end
 
+function _utils.continue(fn)
+  assert(type(fn) == 'function', 'invalid arguments: (fn : function)')
+  return function (msg)
+    local patternResult = fn(msg)
+
+    if not patternResult or patternResult == 0 or patternResult == "skip" then
+      return patternResult
+    end
+    return 1
+  end
+end
 
 return _utils

--- a/process/handlers-utils.md
+++ b/process/handlers-utils.md
@@ -48,6 +48,14 @@ Sends a reply to the sender of a message. The reply can be a simple string or a 
 
 - **Returns:** Function that takes a message object and sends the specified reply.
 
+### continue(fn)
+Inverts the provided pattern matching function's result if it matches, so that it continues execution with the next matching handler.
+
+- **Parameters:**
+  - `fn` (function): Pattern matcher function that returns `"skip"`, `false` or `0` if it does not match.
+
+- **Returns:** Function that executes the pattern matcher and returns `1` (continue), so that the execution of handlers continues.
+
 ## Usage
 
 1. **Import the module:**
@@ -95,6 +103,17 @@ Sends a reply to the sender of a message. The reply can be a simple string or a 
    ```lua
    local replyWithTable = _utils.reply({Tags = {status = 'received'}})
    replyWithTable(message)
+   ```
+
+6. **Continue execution shortcut:**
+   
+   ```lua
+   local isUrgent = _utils.continue(_utils.hasMatchingTag('priority', 'urgent'))
+   if isUrgent(message) ~= 0 then
+     print('This is an urgent message!')
+   end
+   if isUrgent(message) == -1 then return end
+   print('This message will continue')
    ```
 
 ## Conventions and Requirements

--- a/process/handlers-utils.md
+++ b/process/handlers-utils.md
@@ -23,6 +23,15 @@ Checks if a given message has a tag that matches the specified name and value.
 
 - **Returns:** Function that takes a message object and returns `-1` if the tag matches, `0` otherwise.
 
+### hasMatchingTagOf(name, values)
+Checks if a given message has a tag that matches the specified name and one of the specified values.
+
+- **Parameters:**
+  - `name` (string): The name of the tag to check.
+  - `values` (string): The values of which one should match.
+
+- **Returns:** Function that takes a message object and returns `-1` if the tag matches, `0` otherwise.
+
 ### hasMatchingData(value)
 Checks if the message data matches the specified value.
 
@@ -56,7 +65,16 @@ Sends a reply to the sender of a message. The reply can be a simple string or a 
    end
    ```
 
-3. **Check if the message data matches a value:**
+3. **Check for a specific tag with multiple possible values allowed:**
+   
+   ```lua
+   local isNotUrgent = _utils.hasMatchingTagOf('priority', { 'trivial', 'unimportant' })
+   if isNotUrgent(message) == -1 then
+     print('This is not an urgent message!')
+   end
+   ```
+
+4. **Check if the message data matches a value:**
 
    ```lua
    local isHello = _utils.hasMatchingData('Hello')
@@ -65,7 +83,7 @@ Sends a reply to the sender of a message. The reply can be a simple string or a 
    end
    ```
 
-4. **Reply to a message:**
+5. **Reply to a message:**
 
    ```lua
    local replyWithText = _utils.reply('Thank you for your message!')

--- a/process/handlers-utils.md
+++ b/process/handlers-utils.md
@@ -52,9 +52,9 @@ Sends a reply to the sender of a message. The reply can be a simple string or a 
 Inverts the provided pattern matching function's result if it matches, so that it continues execution with the next matching handler.
 
 - **Parameters:**
-  - `fn` (function): Pattern matcher function that returns `"skip"`, `false` or `0` if it does not match.
+  - `fn` (function): Pattern matching function that returns `"skip"`, `false` or `0` if it does not match.
 
-- **Returns:** Function that executes the pattern matcher and returns `1` (continue), so that the execution of handlers continues.
+- **Returns:** Function that executes the pattern matching function and returns `1` (continue), so that the execution of handlers continues.
 
 ## Usage
 


### PR DESCRIPTION
This PR adds 2 new utility functions for handlers:
- `continue()`
   Allows wrapping pattern matching functions (such as the built in `hasMatchingTag()`) so that instead of "breaking" at the end of the handler's execution, they allow the process to continue executing other matching handlers.
   ```lua
   -- useful for built in pattern matching functions
   Handlers.add(
      "stake",
      -- this handler will stake tokens, then it will "continue"
      Handlers.utils.continue(Handlers.utils.hasMatchingTag("Action", "Stake")),
      staking.stake
   )
   ```
- `hasMatchingTagOf()`
   Allows matching multiple values for a tag.
   ```lua
   -- useful for finalizers
   Handlers.add(
      "finalizer",
      -- this handler will finalize results for both the "stake" and "unstake" actions
      Handlers.utils.hasMatchingTagOf("Action", { "Stake", "Unstake" }),
      staking.finalize
   )
   ```