### PR TITLE
fix: check balance handler

### DIFF
--- a/blueprints/token.lua
+++ b/blueprints/token.lua
@@ -51,12 +51,12 @@ if not Logo then Logo = 'SBCCXwwecBlDqRLUjb8dYABExTJXLieawf7m2aBJ-KY' end
    ]]
 --
 Handlers.add('info', Handlers.utils.hasMatchingTag('Action', 'Info'), function(msg)
-  ao.send({ 
-    Target = msg.From, 
-    Name = Name, 
-    Ticker = Ticker, 
-    Logo = Logo, 
-    Denomination = tostring(Denomination) 
+  ao.send({
+    Target = msg.From,
+    Name = Name,
+    Ticker = Ticker,
+    Logo = Logo,
+    Denomination = tostring(Denomination)
   })
 end)
 
@@ -66,19 +66,19 @@ end)
 --
 Handlers.add('balance', Handlers.utils.hasMatchingTag('Action', 'Balance'), function(msg)
   local bal = '0'
-  
-  -- If not Target is provided, then return the Senders balance
-  if (msg.Tags.Target and Balances[msg.Tags.Target]) then
-    bal = Balances[msg.Tags.Target]
+
+  -- If not Recipient is provided, then return the Senders balance
+  if (msg.Tags.Recipient and Balances[msg.Tags.Recipient]) then
+    bal = Balances[msg.Tags.Recipient]
   elseif Balances[msg.From] then
     bal = Balances[msg.From]
   end
 
   ao.send({
     Target = msg.From,
-    Balance = bal, 
+    Balance = bal,
     Ticker = Ticker,
-    Account = msg.Tags.Target or msg.From, 
+    Account = msg.Tags.Target or msg.From,
     Data = bal
   })
 end)
@@ -98,7 +98,7 @@ Handlers.add('transfer', Handlers.utils.hasMatchingTag('Action', 'Transfer'), fu
   assert(type(msg.Recipient) == 'string', 'Recipient is required!')
   assert(type(msg.Quantity) == 'string', 'Quantity is required!')
   assert(bint.__lt(0, bint(msg.Quantity)), 'Quantity must be greater than 0')
-  
+
   if not Balances[msg.From] then Balances[msg.From] = "0" end
   if not Balances[msg.Recipient] then Balances[msg.Recipient] = "0" end
 
@@ -107,7 +107,7 @@ Handlers.add('transfer', Handlers.utils.hasMatchingTag('Action', 'Transfer'), fu
   if bint.__le(qty, balance) then
     Balances[msg.From] = tostring(bint.__sub(balance, qty))
     Balances[msg.Recipient] = tostring(bint.__add(Balances[msg.Recipient], qty))
-  
+
     --[[
          Only send the notifications to the Sender and Recipient
          if the Cast tag is not set on the Transfer message
@@ -117,25 +117,29 @@ Handlers.add('transfer', Handlers.utils.hasMatchingTag('Action', 'Transfer'), fu
       -- Send Debit-Notice to the Sender
       ao.send({
         Target = msg.From,
-        Action = 'Debit-Notice', 
-        Recipient = msg.Recipient, 
+        Action = 'Debit-Notice',
+        Recipient = msg.Recipient,
         Quantity = tostring(qty),
-        Data = Colors.gray .. "You transferred " .. Colors.blue .. msg.Quantity .. Colors.gray .. " to " .. Colors.green .. msg.Recipient .. Colors.reset 
+        Data = Colors.gray ..
+        "You transferred " ..
+        Colors.blue .. msg.Quantity .. Colors.gray .. " to " .. Colors.green .. msg.Recipient .. Colors.reset
       })
       -- Send Credit-Notice to the Recipient
       ao.send({
         Target = msg.Recipient,
-        Action = 'Credit-Notice', 
-        Sender = msg.From, 
+        Action = 'Credit-Notice',
+        Sender = msg.From,
         Quantity = tostring(qty),
-        Data = Colors.gray .. "You received " .. Colors.blue .. msg.Quantity .. Colors.gray .. " from " .. Colors.green .. msg.Recipient .. Colors.reset 
+        Data = Colors.gray ..
+        "You received " ..
+        Colors.blue .. msg.Quantity .. Colors.gray .. " from " .. Colors.green .. msg.Recipient .. Colors.reset
       })
     end
   else
     ao.send({
       Target = msg.From,
-      Action = 'Transfer-Error', 
-      ['Message-Id'] = msg.Id, 
+      Action = 'Transfer-Error',
+      ['Message-Id'] = msg.Id,
       Error = 'Insufficient Balance!'
     })
   end
@@ -145,10 +149,10 @@ end)
     Mint
    ]]
 --
-Handlers.add('mint', Handlers.utils.hasMatchingTag('Action', 'Mint'), function (msg)
+Handlers.add('mint', Handlers.utils.hasMatchingTag('Action', 'Mint'), function(msg)
   assert(type(msg.Quantity) == 'string', 'Quantity is required!')
   assert(bint.__lt(0, msg.Quantity), 'Quantity must be greater than zero!')
-  
+
   if not Balances[ao.id] then Balances[ao.id] = "0" end
 
   if msg.From == ao.id then

--- a/blueprints/token.lua
+++ b/blueprints/token.lua
@@ -78,7 +78,7 @@ Handlers.add('balance', Handlers.utils.hasMatchingTag('Action', 'Balance'), func
     Target = msg.From,
     Balance = bal,
     Ticker = Ticker,
-    Account = msg.Tags.Target or msg.From,
+    Account = msg.Tags.Recipient or msg.From,
     Data = bal
   })
 end)
@@ -121,8 +121,8 @@ Handlers.add('transfer', Handlers.utils.hasMatchingTag('Action', 'Transfer'), fu
         Recipient = msg.Recipient,
         Quantity = tostring(qty),
         Data = Colors.gray ..
-        "You transferred " ..
-        Colors.blue .. msg.Quantity .. Colors.gray .. " to " .. Colors.green .. msg.Recipient .. Colors.reset
+            "You transferred " ..
+            Colors.blue .. msg.Quantity .. Colors.gray .. " to " .. Colors.green .. msg.Recipient .. Colors.reset
       })
       -- Send Credit-Notice to the Recipient
       ao.send({
@@ -131,8 +131,8 @@ Handlers.add('transfer', Handlers.utils.hasMatchingTag('Action', 'Transfer'), fu
         Sender = msg.From,
         Quantity = tostring(qty),
         Data = Colors.gray ..
-        "You received " ..
-        Colors.blue .. msg.Quantity .. Colors.gray .. " from " .. Colors.green .. msg.Recipient .. Colors.reset
+            "You received " ..
+            Colors.blue .. msg.Quantity .. Colors.gray .. " from " .. Colors.green .. msg.Recipient .. Colors.reset
       })
     end
   else


### PR DESCRIPTION
```
  if (msg.Tags.Target and Balances[msg.Tags.Target]) then
    bal = Balances[msg.Tags.Target]
  elseif Balances[msg.From] then
    bal = Balances[msg.From]
  end
```

Above is the code for previous handler where we are taking the value of `Target` tag to fetch the balance however, `Target` tag will always contains the pid for the `token blueprint` as it is a defined tag for `Send` function. Hence, I changed it to `Recipient` to check balance which follows the transfer terminologies.