### PR TITLE
fix(blueprints): remove dump code in arena.lua

### DIFF
--- a/blueprints/arena.lua
+++ b/blueprints/arena.lua
@@ -176,7 +176,6 @@ function endGame()
     print("Game Over")
 
     Winners = 0
-    Winnings = tonumber(BonusQty) / Winners -- Calculating winnings per player
 
     for player, _ in pairs(Players) do
         Winners = Winners + 1


### PR DESCRIPTION
This code seems not correct, which divide by zero first.