### PR TITLE
Fix handler utils `hasMatchingTagOf()` pattern

### DIFF
--- a/process/handlers-utils.lua
+++ b/process/handlers-utils.lua
@@ -17,7 +17,7 @@ function _utils.hasMatchingTagOf(name, values)
     for _, value in ipairs(values) do
       local patternResult = Handlers.utils.hasMatchingTag(name, value)(msg)
 
-      if patternResult ~= 0 then
+      if patternResult ~= 0 and patternResult ~= false and patternResult ~= "skip" then
         return patternResult
       end
     end


### PR DESCRIPTION
Currently the implementation returns wrong results if the matching tag value is not the first one in the loop. This is caused by the differently formatted result from the `hasMatchingTag()` pattern.