### PR TITLE
Forwarded tags support

### DIFF
--- a/blueprints/token.lua
+++ b/blueprints/token.lua
@@ -114,8 +114,8 @@ Handlers.add('transfer', Handlers.utils.hasMatchingTag('Action', 'Transfer'), fu
        ]]
     --
     if not msg.Cast then
-      -- Send Debit-Notice to the Sender
-      ao.send({
+      -- Debit-Notice message template, that is sent to the Sender of the transfer
+      local debitNotice = {
         Target = msg.From,
         Action = 'Debit-Notice',
         Recipient = msg.Recipient,
@@ -123,9 +123,9 @@ Handlers.add('transfer', Handlers.utils.hasMatchingTag('Action', 'Transfer'), fu
         Data = Colors.gray ..
             "You transferred " ..
             Colors.blue .. msg.Quantity .. Colors.gray .. " to " .. Colors.green .. msg.Recipient .. Colors.reset
-      })
-      -- Send Credit-Notice to the Recipient
-      ao.send({
+      }
+      -- Credit-Notice message template, that is sent to the Recipient of the transfer
+      local creditNotice = {
         Target = msg.Recipient,
         Action = 'Credit-Notice',
         Sender = msg.From,
@@ -133,7 +133,20 @@ Handlers.add('transfer', Handlers.utils.hasMatchingTag('Action', 'Transfer'), fu
         Data = Colors.gray ..
             "You received " ..
             Colors.blue .. msg.Quantity .. Colors.gray .. " from " .. Colors.green .. msg.From .. Colors.reset
-      })
+      }
+
+      -- Add forwarded tags to the credit and debit notice messages
+      for tagName, tagValue in pairs(msg) do
+        -- Tags beginning with "X-" are forwarded
+        if string.sub(tagName, 1, 2) == "X-" then
+          debitNotice[tagName] = tagValue
+          creditNotice[tagName] = tagValue
+        end
+      end
+
+      -- Send Debit-Notice and Credit-Notice
+      ao.send(debitNotice)
+      ao.send(creditNotice)
     end
   else
     ao.send({


### PR DESCRIPTION
After the conversation at #214, I have gone ahead and created a basic implementation for forwarded tags. 
This forwards any tags coming from a transfer that begins with the prefix `X-` with the `Credit-Notice` and `Debit-Notice` messages. It does not forward the tags for transfer error messages, I'm happy to add it there as well. 

Some points that are worth noting for the future (all mentioned in the conversations had around this feature, so this is just a summary):
- `X-` is used as a prefix after the customary `X-` prefix for http headers (indicating that the header is of a non-standard name). Generally ao (and Arweave) tries to follow the http header syntax
- Forwarded tags are not encoded in a single tag as a JSON string, because:
  - JSON stringy are hard to query via GraphQL
  - Tags have a limit of 4096 Bytes. In many cases, it is possible that multiple tags together as a JSON string can reach this limit

I think this should satisfy most needs that require chaining messages for transfers, while also maintaining the conservative approach to ao specs updates that many prefer.

Related:
- https://github.com/permaweb/aos/pull/214
- https://github.com/permaweb/aos/pull/212