### PR TITLE
Better error messages

### DIFF
--- a/src/commands/load.js
+++ b/src/commands/load.js
@@ -31,7 +31,8 @@ export function load(line) {
   
     const projectStructure = createProjectStructure(filePath)
 
-    line = createExecutableFromProject(projectStructure)
+    const [executable, modules] = createExecutableFromProject(projectStructure)
+    line = executable
     spinner.stop()
 
     if (projectStructure.length > 0) {
@@ -45,7 +46,7 @@ export function load(line) {
       }))))
     }
 
-    return line
+    return [line, modules]
   } else {
     throw Error(chalk.red('ERROR: .load function requires a *.lua file'))
   }

--- a/src/index.js
+++ b/src/index.js
@@ -326,7 +326,7 @@ if (!argv['watch']) {
 
         if (result?.Error || result?.error) {
           const error = parseError(result.Error || result.error);
-          
+
           if (error) {
             const lineNumberPlaceholder = " ".repeat(error.lineNumber.toString().length);
 
@@ -337,7 +337,7 @@ if (!argv['watch']) {
               chalk.black(line.split("\n")[error.lineNumber - 1]) +
               "\n" +
               chalk.blue(`  ${lineNumberPlaceholder}  |\n`) +
-              chalk.dim("This error occurred while evaluating the submitted code.")
+              chalk.dim("This error occurred while aos was evaluating the submitted code.")
             )
           } else {
             console.log(chalk.red(result.Error || result.error));

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ import { unmonitor } from './commands/unmonitor.js'
 import { loadBlueprint } from './commands/blueprints.js'
 import { help, replHelp } from './services/help.js'
 import { list } from './services/list.js'
+import { parseError } from './services/errors.js'
 
 const argv = minimist(process.argv.slice(2))
 let luaData = ""
@@ -323,10 +324,24 @@ if (!argv['watch']) {
         // log output
         spinner.stop()
 
-        if (result.Error) {
-          console.log(chalk.red(result.Error))
-        } else if (result.error) {
-          console.log(chalk.red(result.error))
+        if (result?.Error || result?.error) {
+          const error = parseError(result.Error || result.error);
+          
+          if (error) {
+            const lineNumberPlaceholder = " ".repeat(error.lineNumber.toString().length);
+
+            console.log(
+              chalk.bold(chalk.red("Error: " + error.errorMessage)) +
+              "\n" +
+              chalk.blue(`  ${lineNumberPlaceholder}  |\n  ${error.lineNumber}  |    `) +
+              chalk.black(line.split("\n")[error.lineNumber - 1]) +
+              "\n" +
+              chalk.blue(`  ${lineNumberPlaceholder}  |\n`) +
+              chalk.dim("This error occurred while evaluating the submitted code.")
+            )
+          } else {
+            console.log(chalk.red(result.Error || result.error));
+          }
         } else {
 
           if (output?.data) {

--- a/src/services/errors.js
+++ b/src/services/errors.js
@@ -22,6 +22,12 @@ export function parseError(error) {
   // parse line number
   const lineNumbers = error.match(/:([0-9]*):/g)
   if (!lineNumbers) return undefined
+  if (lineNumbers.length === 1) {
+    return {
+      lineNumber: 1,
+      errorMessage
+    }
+  } 
 
   // (it's going to be the last ":linenumber:")
   const lineNumber = parseInt(lineNumbers[lineNumbers.length - 1].replace(/:/g, ''))

--- a/src/services/errors.js
+++ b/src/services/errors.js
@@ -1,0 +1,26 @@
+/**
+ * Parse an error result string
+ * @param {string} error Error result
+ */
+export function parseError(error) {
+  // parse error message
+  const errorMessage = error.replace(
+    /\[string "[a-zA-Z0-9_.-]*"\]:[0-9]*: /g,
+    ""
+  );
+
+  // parse line number
+  const lineNumbers = error.match(/:([0-9]*):/g);
+  if (!lineNumbers) return undefined;
+
+  // (it's going to be the last ":linenumber:")
+  const lineNumber = parseInt(
+    lineNumbers[lineNumbers.length - 1]?.replace(/:/g, "") || 
+    "1"
+  );
+
+  return {
+    lineNumber,
+    errorMessage
+  };
+}

--- a/src/services/errors.js
+++ b/src/services/errors.js
@@ -53,27 +53,20 @@ export function getErrorOrigin(loadedModules, lineNumber) {
     }
   }
 
-  // get which file the line is in
   let currentLine = 0
 
-  // get the end position of this file in the executable
-  // "+5" is the line breaks and the extra content aos adds
-  // to the contents
-  const getFilePosition = (content) =>
-    (content?.split('\n')?.length || 0) + 5
-  
-  for (let i = 0; i < loadedModules.length; i++) {
-    const pos = getFilePosition(loadedModules[i].content)
+  for (let i = 0; i < loadedModules.length; i++) {
+    // get module line count
+    const lineCount = (loadedModules[i].content.match(/\r?\n/g)?.length || 0) + 1
 
-    if (currentLine + pos < lineNumber) {
-      currentLine += pos
-      continue
+    if (currentLine + lineCount >= lineNumber) {
+      return {
+        file: loadedModules[i].path,
+        line: lineNumber - currentLine - i * 2
+      }
     }
 
-    return {
-      file: loadedModules[i].path,
-      line: lineNumber - currentLine
-    }
+    currentLine += lineCount
   }
 
   return undefined
@@ -86,7 +79,7 @@ export function getErrorOrigin(loadedModules, lineNumber) {
  * @param {ErrorOrigin|undefined} origin
  */
 export function outputError(line, error, origin) {
-  const lineNumber = origin.line || error.lineNumber
+  const lineNumber = origin?.line || error.lineNumber
   const lineNumberPlaceholder = ' '.repeat(lineNumber.toString().length)
 
   console.log(

--- a/src/services/errors.js
+++ b/src/services/errors.js
@@ -23,8 +23,10 @@ export function parseError(error) {
   const lineNumbers = error.match(/:([0-9]*):/g)
   if (!lineNumbers) return undefined
   if (lineNumbers.length === 1) {
+    const lineNumber = parseInt(errorMessage.match(/(?<=at line )[0-9]+/g) || 1)
+
     return {
-      lineNumber: 1,
+      lineNumber,
       errorMessage
     }
   } 

--- a/src/services/errors.js
+++ b/src/services/errors.js
@@ -57,11 +57,12 @@ export function getErrorOrigin(loadedModules, lineNumber) {
   let currentLine = 0
 
   // get the end position of this file in the executable
-  // "+1" is the line break
+  // "+5" is the line breaks and the extra content aos adds
+  // to the contents
   const getFilePosition = (content) =>
-    (content?.split('\n')?.length || 0) + 1
+    (content?.split('\n')?.length || 0) + 5
   
-  for (let i = 0; i < loadedModules; i++) {
+  for (let i = 0; i < loadedModules.length; i++) {
     const pos = getFilePosition(loadedModules[i].content)
 
     if (currentLine + pos < lineNumber) {
@@ -71,7 +72,7 @@ export function getErrorOrigin(loadedModules, lineNumber) {
 
     return {
       file: loadedModules[i].path,
-      line: lineNumber - pos
+      line: lineNumber - currentLine
     }
   }
 
@@ -91,7 +92,7 @@ export function outputError(line, error, origin) {
   console.log(
     chalk.bold(chalk.red('error') + ': ' + error.errorMessage) +
     '\n' +
-    origin ? chalk.dim(`  in ${origin.file}\n`) : "" +
+    (origin ? chalk.dim(`  in ${origin.file}\n`) : "") +
     chalk.blue(` ${lineNumberPlaceholder} |\n ${lineNumber} |    `) +
     line.split('\n')[error.lineNumber - 1] +
     '\n' +

--- a/src/services/errors.js
+++ b/src/services/errors.js
@@ -1,26 +1,48 @@
 /**
+ * @typedef AOSError
+ * @property {number} lineNumber
+ * @property {string} errorMessage
+ */
+
+/**
  * Parse an error result string
  * @param {string} error Error result
+ * @returns {AOSError}
  */
 export function parseError(error) {
   // parse error message
   const errorMessage = error.replace(
     /\[string "[a-zA-Z0-9_.-]*"\]:[0-9]*: /g,
-    ""
-  );
+    ''
+  )
 
   // parse line number
-  const lineNumbers = error.match(/:([0-9]*):/g);
-  if (!lineNumbers) return undefined;
+  const lineNumbers = error.match(/:([0-9]*):/g)
+  if (!lineNumbers) return undefined
 
   // (it's going to be the last ":linenumber:")
-  const lineNumber = parseInt(
-    lineNumbers[lineNumbers.length - 1]?.replace(/:/g, "") || 
-    "1"
-  );
+  const lineNumber = parseInt(lineNumbers[lineNumbers.length - 1].replace(/:/g, ""))
 
   return {
     lineNumber,
     errorMessage
-  };
+  }
+}
+
+/**
+ * Format and output an error coming from an evaluation
+ * @param {AOSError} error
+ */
+export function outputError(error) {
+  const lineNumberPlaceholder = " ".repeat(error.lineNumber.toString().length)
+
+  console.log(
+    chalk.bold(chalk.red("Error: " + error.errorMessage)) +
+    "\n" +
+    chalk.blue(`  ${lineNumberPlaceholder}  |\n  ${error.lineNumber}  |    `) +
+    chalk.black(line.split("\n")[error.lineNumber - 1]) +
+    "\n" +
+    chalk.blue(`  ${lineNumberPlaceholder}  |\n`) +
+    chalk.dim("This error occurred while aos was evaluating the submitted code.")
+  )
 }

--- a/src/services/errors.js
+++ b/src/services/errors.js
@@ -48,7 +48,7 @@ export function getErrorOrigin(loadedModules, lineNumber) {
   if (!loadedModules) return undefined
   if (loadedModules.length === 1) {
     return {
-      file: path.basename(loadedModules[0].path),
+      file: loadedModules[0].path,
       line: undefined
     }
   }

--- a/src/services/errors.js
+++ b/src/services/errors.js
@@ -1,3 +1,6 @@
+import chalk from 'chalk'
+import path from 'path'
+
 /**
  * @typedef AOSError
  * @property {number} lineNumber
@@ -21,7 +24,7 @@ export function parseError(error) {
   if (!lineNumbers) return undefined
 
   // (it's going to be the last ":linenumber:")
-  const lineNumber = parseInt(lineNumbers[lineNumbers.length - 1].replace(/:/g, ""))
+  const lineNumber = parseInt(lineNumbers[lineNumbers.length - 1].replace(/:/g, ''))
 
   return {
     lineNumber,
@@ -30,19 +33,69 @@ export function parseError(error) {
 }
 
 /**
- * Format and output an error coming from an evaluation
- * @param {AOSError} error
+ * @typedef ErrorOrigin
+ * @property {string} file
+ * @property {number|undefined} line
  */
-export function outputError(error) {
-  const lineNumberPlaceholder = " ".repeat(error.lineNumber.toString().length)
+
+/**
+ * Get error origin file and actual line number
+ * @param {Module[]} loadedModules 
+ * @param {number} lineNumber
+ * @returns {ErrorOrigin|undefined}
+ */
+export function getErrorOrigin(loadedModules, lineNumber) {
+  if (!loadedModules) return undefined
+  if (loadedModules.length === 1) {
+    return {
+      file: path.basename(loadedModules[0].path),
+      line: undefined
+    }
+  }
+
+  // get which file the line is in
+  let currentLine = 0
+
+  // get the end position of this file in the executable
+  // "+1" is the line break
+  const getFilePosition = (content) =>
+    (content?.split('\n')?.length || 0) + 1
+  
+  for (let i = 0; i < loadedModules; i++) {
+    const pos = getFilePosition(loadedModules[i].content)
+
+    if (currentLine + pos < lineNumber) {
+      currentLine += pos
+      continue
+    }
+
+    return {
+      file: loadedModules[i].path,
+      line: lineNumber - pos
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Format and output an error coming from an evaluation
+ * @param {string} line
+ * @param {AOSError} error
+ * @param {ErrorOrigin|undefined} origin
+ */
+export function outputError(line, error, origin) {
+  const lineNumber = origin.line || error.lineNumber
+  const lineNumberPlaceholder = ' '.repeat(lineNumber.toString().length)
 
   console.log(
-    chalk.bold(chalk.red("Error: " + error.errorMessage)) +
-    "\n" +
-    chalk.blue(`  ${lineNumberPlaceholder}  |\n  ${error.lineNumber}  |    `) +
-    chalk.black(line.split("\n")[error.lineNumber - 1]) +
-    "\n" +
-    chalk.blue(`  ${lineNumberPlaceholder}  |\n`) +
-    chalk.dim("This error occurred while aos was evaluating the submitted code.")
+    chalk.bold(chalk.red('error') + ': ' + error.errorMessage) +
+    '\n' +
+    origin ? chalk.dim(`  in ${origin.file}\n`) : "" +
+    chalk.blue(` ${lineNumberPlaceholder} |\n ${lineNumber} |    `) +
+    line.split('\n')[error.lineNumber - 1] +
+    '\n' +
+    chalk.blue(` ${lineNumberPlaceholder} |\n`) +
+    chalk.dim('This error occurred while aos was evaluating the submitted code.')
   )
 }


### PR DESCRIPTION
This PR adds error parsing and improved error messages. It parses the origin of the error and displays it.
Before:
<img width="497" alt="Screenshot 2024-05-02 at 10 17 15 PM" src="https://github.com/permaweb/aos/assets/30638105/2db4beb7-ff12-4060-ae85-0af885c4f4a4">
After:
<img width="459" alt="Screenshot 2024-05-02 at 10 15 38 PM" src="https://github.com/permaweb/aos/assets/30638105/eb4e9f62-5431-4787-96f4-4d41a18ff949">
It can also handle errors from loaded projects and point to the original (local) file where the error occurred.