### PR TITLE
Fix: Add Message-Id in CreditNotice and DebitNotice

### DIFF
--- a/blueprints/token.lua
+++ b/blueprints/token.lua
@@ -141,6 +141,7 @@ Handlers.add('transfer', Handlers.utils.hasMatchingTag('Action', 'Transfer'), fu
         Action = 'Debit-Notice',
         Recipient = msg.Recipient,
         Quantity = msg.Quantity,
+        ['Message-Id'] = msg.Id,
         Data = Colors.gray ..
             "You transferred " ..
             Colors.blue .. msg.Quantity .. Colors.gray .. " to " .. Colors.green .. msg.Recipient .. Colors.reset
@@ -151,6 +152,7 @@ Handlers.add('transfer', Handlers.utils.hasMatchingTag('Action', 'Transfer'), fu
         Action = 'Credit-Notice',
         Sender = msg.From,
         Quantity = msg.Quantity,
+        ['Message-Id'] = msg.Id,
         Data = Colors.gray ..
             "You received " ..
             Colors.blue .. msg.Quantity .. Colors.gray .. " from " .. Colors.green .. msg.From .. Colors.reset


### PR DESCRIPTION
This PR adds the `Message-Id` tag to the Credit-Notice and the Debit-Notice.

This tag already existed in the Transfer-Error and the Mint-Error messages, and could be really helpful to know which Transfer message triggered the notices 😄 