### PR TITLE
Fix number inputs for spawn tags

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -65,11 +65,14 @@ export function register(jwk, services) {
 
   let spawnTags = Array.isArray(argv["tag-name"]) ?
     argv["tag-name"].map((name, i) => ({
-      name,
-      value: argv["tag-value"][i]
+      name: String(name || ""),
+      value: String(argv["tag-value"][i] || "")
     })) : [];
   if (spawnTags.length === 0 && typeof argv["tag-name"] === "string") {
-    spawnTags = [{ name: argv["tag-name"], value: argv["tag-value"] || "" }]
+    spawnTags = [{
+      name: String(argv["tag-name"] || ""),
+      value: String(argv["tag-value"] || "")
+    }]
   }
   if (name.length === 43) {
     return of(name)


### PR DESCRIPTION
This PR fixes an issue where if you have a number as a `--tag-value` when spawning a new aos process, it errors, because tags can only be strings. The fix converts all inputs to strings.