### PR TITLE
feat: Added optional Note to transfer messages

### DIFF
--- a/blueprints/token.lua
+++ b/blueprints/token.lua
@@ -144,7 +144,8 @@ Handlers.add('transfer', Handlers.utils.hasMatchingTag('Action', 'Transfer'), fu
         Quantity = msg.Quantity,
         Data = Colors.gray ..
             "You transferred " ..
-            Colors.blue .. msg.Quantity .. Colors.gray .. " to " .. Colors.green .. msg.Recipient .. Colors.reset
+            Colors.blue .. msg.Quantity .. Colors.gray .. " to " .. Colors.green .. msg.Recipient .. Colors.reset,
+        Note = msg.Note or nil
       }
       -- Credit-Notice message template, that is sent to the Recipient of the transfer
       local creditNotice = {
@@ -154,7 +155,8 @@ Handlers.add('transfer', Handlers.utils.hasMatchingTag('Action', 'Transfer'), fu
         Quantity = msg.Quantity,
         Data = Colors.gray ..
             "You received " ..
-            Colors.blue .. msg.Quantity .. Colors.gray .. " from " .. Colors.green .. msg.From .. Colors.reset
+            Colors.blue .. msg.Quantity .. Colors.gray .. " from " .. Colors.green .. msg.From .. Colors.reset,
+        Note = msg.Note or nil
       }
 
       -- Add forwarded tags to the credit and debit notice messages


### PR DESCRIPTION
Very minor update to include an optional Note field in debit and credit notices.

This allows users to add `Note = 'x'` to their Transfer requests and both the sender and recipient will receive the note in their debit/credit notices.

If there is no Note field in the Transfer request, no Note is added to the debit/credit notices.

In addition to providing more information on simple transfers, this update would allow processes that take in payments to process those payments more efficiently, especially when those processes offer multiple services and need to determine what each payment is intended for.