### PR TITLE
Return TotalSupply with Info and remove totalSupply handler

### DIFF
--- a/blueprints/token.lua
+++ b/blueprints/token.lua
@@ -78,7 +78,8 @@ Handlers.add('info', Handlers.utils.hasMatchingTag('Action', 'Info'), function(m
     Name = Name,
     Ticker = Ticker,
     Logo = Logo,
-    Denomination = tostring(Denomination)
+    Denomination = tostring(Denomination),
+    TotalSupply = TotalSupply
   })
 end)
 
@@ -206,21 +207,6 @@ Handlers.add('mint', Handlers.utils.hasMatchingTag('Action', 'Mint'), function(m
       Error = 'Only the Process Id can mint new ' .. Ticker .. ' tokens!'
     })
   end
-end)
-
---[[
-     Total Supply
-   ]]
---
-Handlers.add('totalSupply', Handlers.utils.hasMatchingTag('Action', 'Total-Supply'), function(msg)
-  assert(msg.From ~= ao.id, 'Cannot call Total-Supply from the same process!')
-
-  ao.send({
-    Target = msg.From,
-    Action = 'Total-Supply',
-    Data = TotalSupply,
-    Ticker = Ticker
-  })
 end)
 
 --[[


### PR DESCRIPTION
PR #242 made a change so that the total supply is no longer calculated on the fly This change adds the TotalSupply property to the object returned from the Info handler

The totalSupply handler has been removed, as this data is now included in the Info handler response.