### PR TITLE
fix: variable clash with the process' global variable: 'Name' in the token blueprint

### DIFF
--- a/blueprints/token.lua
+++ b/blueprints/token.lua
@@ -9,7 +9,7 @@ local ao = require('ao')
   It will first initialize the internal state, and then attach handlers,
     according to the ao Standard Token Spec API:
 
-    - Info(): return the token parameters, like Name, Ticker, Logo, and Denomination
+    - Info(): return the token parameters, like TokenName, Ticker, Logo, and Denomination
 
     - Balance(Target?: string): return the token balance of the Target. If Target is not provided, the Sender
         is assumed to be the Target
@@ -59,7 +59,7 @@ Variant = "0.0.3"
 Denomination = Denomination or 12
 Balances = Balances or { [ao.id] = utils.toBalanceValue(10000 * 10 ^ Denomination) }
 TotalSupply = TotalSupply or utils.toBalanceValue(10000 * 10 ^ Denomination)
-Name = Name or 'Points Coin'
+TokenName = TokenName or 'Points Coin'
 Ticker = Ticker or 'PNTS'
 Logo = Logo or 'SBCCXwwecBlDqRLUjb8dYABExTJXLieawf7m2aBJ-KY'
 
@@ -75,7 +75,7 @@ Logo = Logo or 'SBCCXwwecBlDqRLUjb8dYABExTJXLieawf7m2aBJ-KY'
 Handlers.add('info', Handlers.utils.hasMatchingTag('Action', 'Info'), function(msg)
   ao.send({
     Target = msg.From,
-    Name = Name,
+    TokenName = TokenName,
     Ticker = Ticker,
     Logo = Logo,
     Denomination = tostring(Denomination)


### PR DESCRIPTION
Each process has a global var called [Name](https://github.com/permaweb/ao-cookbook/blob/2f0d16932175d55823bc42e4d07cbe9562000b7a/src/guides/aos/intro.md#globals), and this clashes with the token blueprint's Name variable.

The line: [`Name = Name or 'Points Coin'`](https://github.com/permaweb/aos/blob/7d1b482161d3e01dd6c18b3133c93068301497df/blueprints/token.lua#L62) is never assigned, since `Name` already has the value of the process name. (Default or whatever the dev names it)


For example, the dev might name the process `Currency Contract` when instantiating it. In this case, the token never gets the name Points Coin.


This can be fixed by updating the line to: `TokenName = TokenName or 'Points Coin'`
