### PR TITLE
 feat: add support for more expressive handlers.

### DIFF
--- a/process/handlers.lua
+++ b/process/handlers.lua
@@ -1,4 +1,4 @@
-local handlers = { _version = "0.0.4" }
+local handlers = { _version = "0.0.5" }
 
 handlers.utils = require('.handlers-utils')
 handlers.list = {}

--- a/process/handlers.lua
+++ b/process/handlers.lua
@@ -2,6 +2,7 @@ local handlers = { _version = "0.0.4" }
 
 handlers.utils = require('.handlers-utils')
 handlers.list = {}
+handlers.onceNonce = 0
 
 local function findIndexByProp(array, prop, value)
   for index, object in ipairs(array) do

--- a/process/handlers.lua
+++ b/process/handlers.lua
@@ -254,7 +254,6 @@ function handlers.evaluate(msg, env)
         local status, err = pcall(o.handle, msg, env)
         if not status then
           error(err)
-          ao.outbox.Error = { err = err }
         end
         -- remove handler if maxRuns is reached. maxRuns can be either a number or "inf"
         if o.maxRuns ~= nil and o.maxRuns ~= "inf" then

--- a/process/handlers.lua
+++ b/process/handlers.lua
@@ -177,8 +177,9 @@ local function matchesPattern(msg, pattern)
           return false
         end
       end
-      -- if the patternMatchSpec is a string, check it for special symbols and exact match mode
-      if not matched and string.match(patternMatchSpec, "[%^%$%(%)%%%.%[%]%*%+%-%?]") then
+      -- if the patternMatchSpec is a string, check it for special symbols (less `-` alone)
+      -- and exact string match mode
+      if not matched and string.match(patternMatchSpec, "[%^%$%(%)%%%.%[%]%*%+%?]") then
         if string.match(msg[key], patternMatchSpec) then
           matched = true
         end

--- a/process/handlers.lua
+++ b/process/handlers.lua
@@ -152,14 +152,13 @@ end
 
 function handlers.remove(name)
   assert(type(name) == 'string', 'Handler name MUST be a string')
-  if #handlers.list == 1 and handlers.list[1].name == name then
-    handlers.list = {}
-    
-  end
-
-  local idx = findIndexByProp(handlers.list, "name", name)
-  table.remove(handlers.list, idx)
   
+  local idx = findIndexByProp(handlers.list, "name", name)
+  if idx then
+    table.remove(handlers.list, idx)
+  else
+    error('Handler not found')
+  end
 end
 
 function handlers.matchesPattern(msg, pattern)

--- a/process/handlers.lua
+++ b/process/handlers.lua
@@ -3,6 +3,7 @@ local handlers = { _version = "0.0.5" }
 handlers.utils = require('.handlers-utils')
 handlers.list = {}
 handlers.onceNonce = 0
+handlers.coroutines = {}
 
 local function findIndexByProp(array, prop, value)
   for index, object in ipairs(array) do
@@ -39,6 +40,18 @@ function handlers.generateResolver(resolveSpec)
         end
     end
   end
+end
+
+-- Returns the next message that matches the pattern
+-- This function uses Lua's coroutines under-the-hood to add a handler, pause,
+-- and then resume the current coroutine. This allows us to effectively block
+-- processing of one message until another is received that matches the pattern.
+function handlers.receive(pattern)
+  local self = coroutine.running()
+  Handlers.once(pattern, function (msg)
+      coroutine.resume(self, msg)
+  end)
+  return coroutine.yield(pattern)
 end
 
 function handlers.once(...)

--- a/process/handlers.lua
+++ b/process/handlers.lua
@@ -225,7 +225,7 @@ function handlers.evaluate(msg, env)
     if o.name ~= "_default" then
       local match = handlers.matchesPattern(msg, o.pattern)
       if not (type(match) == 'number' or type(match) == 'string' or type(match) == 'boolean') then
-        error({message = "pattern result is not valid, it MUST be string, number, or boolean"})
+        error("Pattern result is not valid, it MUST be string, number, or boolean")
       end
       
       -- handle boolean returns

--- a/process/handlers.lua
+++ b/process/handlers.lua
@@ -33,7 +33,7 @@ function handlers.generateResolver(resolveSpec)
       return resolveSpec(msg)
     else
         for matchSpec, func in pairs(resolveSpec) do
-            if Handlers.matchesPattern(msg, matchSpec) then
+            if handlers.matchesPattern(msg, matchSpec) then
                 return func(msg)
             end
         end

--- a/process/process.lua
+++ b/process/process.lua
@@ -94,7 +94,7 @@ function print(a)
     a = stringify.format(a)
   end
   
-  pcall(function () 
+  pcall(function ()
     local data = a
     if _ao.outbox.Output.data then
       data =  _ao.outbox.Output.data .. "\n" .. a

--- a/process/process.lua
+++ b/process/process.lua
@@ -143,6 +143,10 @@ function Spawn(...)
   return res
 end
 
+function Receive(match)
+  return Handlers.receive(match)
+end
+
 function Assign(assignment)
   _ao.assign(assignment)
   print("Assignment added to outbox.")

--- a/process/process.lua
+++ b/process/process.lua
@@ -106,17 +106,41 @@ function print(a)
 end
 
 function Send(msg)
-  _ao.send(msg)
-  return 'message added to outbox'
+  if not msg.Target then
+    print("WARN: No target specified for message. Data will be stored, but no process will receive it.")
+  end
+  local fullMsg = _ao.send(msg)
+  local res = {
+    onReply = fullMsg.onReply,
+    receive = fullMsg.receive
+  }
+  print("Message added to outbox.")
+  return res
 end
 
-function Spawn(module, msg)
-  if not msg then
-    msg = {}
+function Spawn(...)
+  local module, spawnMsg
+
+  if select("#", ...) == 1 then
+    spawnMsg = select(1, ...)
+    module = _ao._module
+  else
+    module = select(1, ...)
+    spawnMsg = select(2, ...)
   end
 
-  _ao.spawn(module, msg)
-  return 'spawn process request'
+  if not spawnMsg then
+    spawnMsg = {}
+  end
+
+  local spawnRes = _ao.spawn(module, spawnMsg)
+  local res = {
+    after = spawnRes.after,
+    receive = spawnRes.receive
+  }
+
+  print("Spawn process request added to outbox.")
+  return res
 end
 
 function Assign(assignment)

--- a/process/process.lua
+++ b/process/process.lua
@@ -145,7 +145,8 @@ end
 
 function Assign(assignment)
   _ao.assign(assignment)
-  return 'assignment added to outbox'
+  print("Assignment added to outbox.")
+  return 'Assignment added to outbox.'
 end
 
 Seeded = Seeded or false


### PR DESCRIPTION
This commit adds support for:
- Handlers.once: A method of adding a single-run handler that is removed after exection.
- Optional MaxRuns argument for each handler, letting you choose the number of runs before it removes itself. Default is infinite.
- More expressive and easy to use matches. As well as functions, handlers now supports:
-> Strings as match, checking against the Action tag.
-> 'MessageMatchSpecs': Partially described messages. In this mode, each tag given in the 'spec' is checked against the value in the message. It allows you to:
    1. Wildcard: Is the tag given at all?
    2. Function: Run a function against the tag value (optional second argument is the full message)
    3. String: Exact match
    4. String: Lua matching syntax