### PR TITLE
fix: Don't crash the AOS CLI when an unknown error occurs on the process.

### DIFF
--- a/src/services/errors.js
+++ b/src/services/errors.js
@@ -13,6 +13,11 @@ import path from 'path'
  * @returns {AOSError}
  */
 export function parseError(error) {
+  // if we have not been given any error information, return a generic message
+  if(!error || Object.keys(error).length === 0) {
+    return {lineNumber: 0, errorMessage: "No message given by process."}
+  }
+
   // parse error message
   const errorMessage = error.replace(
     /\[string "[a-zA-Z0-9_.-]*"\]:[0-9]*: /g,


### PR DESCRIPTION
Without this patch the AOS client crashes completely when the process gives it a response with no error content. This PR makes it instead return a generic error message with a `0` line number.