### PR TITLE
Draft: Subledgers implementation

### DIFF
--- a/blueprints/subledger_code.lua
+++ b/blueprints/subledger_code.lua
@@ -56,27 +56,28 @@ local utils = {
 --
 Variant = "0.0.3"
 
+-- token state should be assigned from the spawning message
 -- token should be idempotent and not change previous state updates
+Name = Name or ao.env.Process.Tags['Token-Name']
+Ticker = Ticker or ao.env.Process.Tags['Token-Ticker']
+Denomination = Denomination or tonumber(ao.env.Process.Tags['Token-Denomination']) or 12
+Logo = Logo or ao.env.Process.Tags['Token-Logo']
+
 if not ao.env.Process.Tags['Parent-Token'] then
-  Name = Name or 'Points Coin'
-  Ticker = Ticker or 'PNTS'
-  Denomination = Denomination or 12
-  Logo = Logo or 'SBCCXwwecBlDqRLUjb8dYABExTJXLieawf7m2aBJ-KY'
+  local initialSupply = tonumber(ao.env.Process.Tags['Token-Supply']) or 10000
+  local initialBalance = utils.toBalanceValue(initialSupply * 10 ^ Denomination)
 
-  Balances = Balances or { [ao.id] = utils.toBalanceValue(10000 * 10 ^ Denomination) }
-  TotalSupply = TotalSupply or utils.toBalanceValue(10000 * 10 ^ Denomination)
+  Balances = Balances or { [ao.id] = initialBalance }
+  TotalSupply = TotalSupply or initialBalance
 else
-  Name = ao.env.Process.Tags['Token-Name']
-  Ticker = ao.env.Process.Tags['Token-Ticker']
-  Denomination = ao.env.Process.Tags['Token-Denomination']
-  Logo = ao.env.Process.Tags['Token-Logo']
-
   Balances = Balances or {}
-
-  -- subledger-only globals
-  ParentToken = ao.env.Process.Tags['Parent-Token']
-  SourceToken = ao.env.Process.Tags['Source-Token']
 end
+
+SourceToken = ao.env.Process.Tags['Source-Token'] or ao.id
+ParentToken = ao.env.Process.Tags['Parent-Token']
+
+Subledgers = Subledgers or {}
+SubledgersPendingInit = SubledgersPendingInit or {}
 
 --[[
      Add handlers for each incoming Action defined by the ao Standard Token Specification

--- a/blueprints/subledger_code.lua
+++ b/blueprints/subledger_code.lua
@@ -48,7 +48,6 @@ local utils = {
   end
 }
 
-
 --[[
      Initialize State
 
@@ -66,9 +65,12 @@ if not ao.env.Process.Tags['Parent-Token'] then
   _G.Ticker = Ticker or 'PNTS'
   _G.Logo = Logo or 'SBCCXwwecBlDqRLUjb8dYABExTJXLieawf7m2aBJ-KY'
 else
-  _G.Balances = {}
+  _G.Balances = Balances or {}
   _G.ParentToken = ao.env.Process.Tags['Parent-Token']
   _G.SourceToken = ao.env.Process.Tags['Source-Token']
+  _G.Name = ao.env.Process.Tags['Token-Name']
+  _G.Ticker = ao.env.Process.Tags['Token-Ticker']
+  _G.Logo = ao.env.Process.Tags['Token-Logo']
 end
 
 --[[
@@ -302,7 +304,6 @@ Handlers.add('withdraw', Handlers.utils.hasMatchingTag('Action', 'Withdraw'), fu
     Quantity = msg.Quantity
   })
 end)
-
 
 ]===]
 

--- a/blueprints/token.lua
+++ b/blueprints/token.lua
@@ -58,27 +58,25 @@ local utils = {
 --
 Variant = "0.0.3"
 
+-- token state should be assigned from the spawning message
 -- token should be idempotent and not change previous state updates
+Name = Name or ao.env.Process.Tags['Token-Name']
+Ticker = Ticker or ao.env.Process.Tags['Token-Ticker']
+Denomination = Denomination or tonumber(ao.env.Process.Tags['Token-Denomination']) or 12
+Logo = Logo or ao.env.Process.Tags['Token-Logo']
+
 if not ao.env.Process.Tags['Parent-Token'] then
-  Name = Name or 'Points Coin'
-  Ticker = Ticker or 'PNTS'
-  Denomination = Denomination or 12
-  Logo = Logo or 'SBCCXwwecBlDqRLUjb8dYABExTJXLieawf7m2aBJ-KY'
+  local initialSupply = tonumber(ao.env.Process.Tags['Token-Supply']) or 10000
+  local initialBalance = utils.toBalanceValue(initialSupply * 10 ^ Denomination)
 
-  Balances = Balances or { [ao.id] = utils.toBalanceValue(10000 * 10 ^ Denomination) }
-  TotalSupply = TotalSupply or utils.toBalanceValue(10000 * 10 ^ Denomination)
+  Balances = Balances or { [ao.id] = initialBalance }
+  TotalSupply = TotalSupply or initialBalance
 else
-  Name = ao.env.Process.Tags['Token-Name']
-  Ticker = ao.env.Process.Tags['Token-Ticker']
-  Denomination = tonumber(ao.env.Process.Tags['Token-Denomination'])
-  Logo = ao.env.Process.Tags['Token-Logo']
-
   Balances = Balances or {}
-
-  -- subledger-only globals
-  ParentToken = ao.env.Process.Tags['Parent-Token']
-  SourceToken = ao.env.Process.Tags['Source-Token']
 end
+
+SourceToken = ao.env.Process.Tags['Source-Token'] or ao.id
+ParentToken = ao.env.Process.Tags['Parent-Token']
 
 Subledgers = Subledgers or {}
 SubledgersPendingInit = SubledgersPendingInit or {}

--- a/blueprints/token.lua
+++ b/blueprints/token.lua
@@ -64,9 +64,12 @@ if not ao.env.Process.Tags['Parent-Token'] then
   _G.Ticker = Ticker or 'PNTS'
   _G.Logo = Logo or 'SBCCXwwecBlDqRLUjb8dYABExTJXLieawf7m2aBJ-KY'
 else
-  _G.Balances = {}
+  _G.Balances = Balances or {}
   _G.ParentToken = ao.env.Process.Tags['Parent-Token']
   _G.SourceToken = ao.env.Process.Tags['Source-Token']
+  _G.Name = ao.env.Process.Tags['Token-Name']
+  _G.Ticker = ao.env.Process.Tags['Token-Ticker']
+  _G.Logo = ao.env.Process.Tags['Token-Logo']
 end
 
 --[[
@@ -316,6 +319,9 @@ Handlers.add('SpawnSubledger', Handlers.utils.hasMatchingTag('Action', 'Spawn-Su
     Tags = {
       ['Source-Token'] = SourceToken,
       ['Parent-Token'] = ao.id,
+      ['Token-Name'] = Name,
+      ['Token-Ticker'] = Ticker,
+      ['Token-Logo'] = Logo,
       ['Deployer'] = msg.From,
       ['Original-Message-Id'] = msg.Id,
     }


### PR DESCRIPTION
This draft implements subledgers as specified in the [specification](https://hackmd.io/@ao-docs/rkewy04uT#) by @samcamwilliams and @twilson63.

Added Handlers for Spawning Processes:
- `Spawn-Subledger`: Handles the spawning of subledger processes with appropriate tags.
- `NotifySpawn`: Collects and prepares subledger initialization data.
- `Init-Subledgers`: Initializes subledgers and notifies the deployer. 

Note: These handlers could potentially be merged into a single handler when [fix on spawn ](https://github.com/permaweb/ao/pull/858) and [#840](https://github.com/permaweb/ao/pull/840) are in production.

Added Handlers for Subledger-Specific Operations:
- `Credit-Notice`: Handles crediting tokens to subledgers.
- `Withdraw`: Manages the withdrawal of tokens from subledgers.

**Improvements Needed:**

- Code Duplication in `subledger_code.lua`: Currently, the code in `subledger_code.lua` is duplicated to assign it to the spawned process. Does anyone know a better way to handle this to avoid redundancy?

- Stack Issues with Init-Subledgers: Due to code duplication, adding the Init-Subledgers code in subledger_code.lua results in a recursive loading problem. This prevents the creation of sub-subledgers and needs to be addressed.
