### PR TITLE
Fix utils.toNumber() in token.lua

### DIFF
--- a/blueprints/token.lua
+++ b/blueprints/token.lua
@@ -42,7 +42,7 @@ local utils = {
     return tostring(bint(a))
   end,
   toNumber = function(a)
-    return tonumber(a)
+    return bint.tonumber(a)
   end
 }
 


### PR DESCRIPTION
Fixes https://github.com/permaweb/aos/issues/288

The current implementation errors on `bint` inputs. Should be using `bint.tonumber(a)` instead of the native `tonumber(a)`