### PR TITLE
MintAndBurnReplyUpdate

### DIFF
--- a/blueprints/token.lua
+++ b/blueprints/token.lua
@@ -196,11 +196,23 @@ Handlers.add('mint', Handlers.utils.hasMatchingTag('Action', 'Mint'), function(m
     -- Add tokens to the token pool, according to Quantity
     Balances[msg.From] = utils.add(Balances[msg.From], msg.Quantity)
     TotalSupply = utils.add(TotalSupply, msg.Quantity)
-    ao.send({
+
+    local mintNotice = {
       Target = msg.From,
       Action = "Mint-Notice",
       Data = Colors.gray .. "Successfully minted " .. Colors.blue .. msg.Quantity .. Colors.reset
-    })
+    }
+
+    -- Add forwarded tags to the mint notice messages
+    for tagName, tagValue in pairs(msg) do
+      -- Tags beginning with "X-" are forwarded
+      if string.sub(tagName, 1, 2) == "X-" then
+        mintNotice[tagName] = tagValue
+      end
+    end
+
+    ao.send(mintNotice)
+
   else
     ao.send({
       Target = msg.From,
@@ -236,9 +248,19 @@ Handlers.add('burn', Handlers.utils.hasMatchingTag('Action', 'Burn'), function(m
   Balances[msg.From] = utils.subtract(Balances[msg.From], msg.Quantity)
   TotalSupply = utils.subtract(TotalSupply, msg.Quantity)
 
-  ao.send({
+  local burnNotice = {
     Target = msg.From,
     Action = "Burn-Notice",
     Data = Colors.gray .. "Successfully burned " .. Colors.blue .. msg.Quantity .. Colors.reset
-  })
+  }
+
+  -- Add forwarded tags to the burn notice messages
+  for tagName, tagValue in pairs(msg) do
+    -- Tags beginning with "X-" are forwarded
+    if string.sub(tagName, 1, 2) == "X-" then
+      burnNotice[tagName] = tagValue
+    end
+  end
+
+  ao.send(burnNotice)
 end)

--- a/blueprints/token.lua
+++ b/blueprints/token.lua
@@ -198,6 +198,7 @@ Handlers.add('mint', Handlers.utils.hasMatchingTag('Action', 'Mint'), function(m
     TotalSupply = utils.add(TotalSupply, msg.Quantity)
     ao.send({
       Target = msg.From,
+      Action = "Mint-Notice",
       Data = Colors.gray .. "Successfully minted " .. Colors.blue .. msg.Quantity .. Colors.reset
     })
   else
@@ -237,6 +238,7 @@ Handlers.add('burn', Handlers.utils.hasMatchingTag('Action', 'Burn'), function(m
 
   ao.send({
     Target = msg.From,
+    Action = "Burn-Notice",
     Data = Colors.gray .. "Successfully burned " .. Colors.blue .. msg.Quantity .. Colors.reset
   })
 end)

--- a/blueprints/token.lua
+++ b/blueprints/token.lua
@@ -200,6 +200,7 @@ Handlers.add('mint', Handlers.utils.hasMatchingTag('Action', 'Mint'), function(m
     local mintNotice = {
       Target = msg.From,
       Action = "Mint-Notice",
+      Quantity = msg.Quantity,
       Data = Colors.gray .. "Successfully minted " .. Colors.blue .. msg.Quantity .. Colors.reset
     }
 
@@ -251,6 +252,7 @@ Handlers.add('burn', Handlers.utils.hasMatchingTag('Action', 'Burn'), function(m
   local burnNotice = {
     Target = msg.From,
     Action = "Burn-Notice",
+    Quantity = msg.Quantity,
     Data = Colors.gray .. "Successfully burned " .. Colors.blue .. msg.Quantity .. Colors.reset
   }
 


### PR DESCRIPTION
This update allows the implementation of extension handlers that listen to Minting and Burning tokens.

Example: I am building a lending protocol that implements my lending blueprint and the token's blueprint. I want to allow lenders to deposit "X" tokens in my lending process and get back temporally tokens that they can later use to claim back their deposited tokens. So, I need a way to listen when my lending process mint new tokens to instantly transfer them to the lender who made a deposit.

Now with this update, I can write handlers to listen to "Mint-Notice" and "Burn-Notice" to do further logic.