### PR TITLE
feat(aos-process): os.time should return the msg.Timestamp #276

### DIFF
--- a/process/process.lua
+++ b/process/process.lua
@@ -191,6 +191,9 @@ function process.handle(msg, ao)
   ao.id = ao.env.Process.Id
   initializeState(msg, ao.env)
   
+  -- set os.time to return msg.Timestamp
+  os.time = function () return msg.Timestamp end
+
   -- tagify msg
   msg.TagArray = msg.Tags
   msg.Tags = Tab(msg)


### PR DESCRIPTION
Closes #276 

### Overview

This PR allows users to access the most recent ```msg.Timestamp``` via ```os.time()``` for a more intuitive user experience.

### Changes

Added a single line to the ```process.handle``` method ```os.time = function () return msg.Timestamp end``` which overides the os.time() method to return msg.Timestamp.

Added a test to handlers.test.js to confirm functionality.
