### PR TITLE
fix(aos-cli): live feed message sorting #275

### DIFF
--- a/src/services/connect.js
+++ b/src/services/connect.js
@@ -165,6 +165,10 @@ export async function live(id, watch) {
           return false
         }))
 
+        // Sort the edges by ordinate value to ensure they are printed in the correct order.
+        // TODO: Handle sorting with Cron jobs, considering nonces and timestamps. Review cursor usage for compatibility with future CU implementations.
+        edges = edges.sort((a, b) => JSON.parse(atob(a.cursor)).ordinate - JSON.parse(atob(b.cursor)).ordinate);
+
         // --- peek on previous line and if delete line if last prompt.
         // --- key event can detect 
         // count !== null && 

--- a/src/services/connect.js
+++ b/src/services/connect.js
@@ -155,7 +155,7 @@ export async function live(id, watch) {
 
         const results = await connect(getInfo()).results(params)
 
-        const edges = uniqBy(prop('cursor'))(results.edges.filter(function (e) {
+        let edges = uniqBy(prop('cursor'))(results.edges.filter(function (e) {
           if (e.node?.Output?.print === true) {
             return true
           }


### PR DESCRIPTION
Closes #275

### Overview

This PR is to address an issue with messages printing out of order in the aos cli.

### Solution

The solution was to sort the `edges` returned from `graphql` by the `ordinate` **_encoded_** inside of the **_base64 decoded_** `cursor`.
Was going to sort by the `timestamp` **_encoded_** inside the `cursor` but the timestamps seem to not be a direct indicator of message order. Most likely due to the asynchronous nature of the CU?

### Changes

Added a single line of code to sort the edges inside the `checkLive` function in `services/connect.js`.
```js
// Sort the edges by ordinate value to ensure they are printed in the correct order.
edges = edges.sort((a, b) => JSON.parse(atob(a.cursor)).ordinate - JSON.parse(atob(b.cursor)).ordinate);
```