### PR TITLE
Add event-type messages to enhance aggregation support

### DIFF
--- a/blueprints/token.lua
+++ b/blueprints/token.lua
@@ -237,12 +237,6 @@ Handlers.add('mint', Handlers.utils.hasMatchingTag('Action', 'Mint'), function(m
       Target = msg.From,
       Data = Colors.gray .. "Successfully minted " .. Colors.blue .. msg.Quantity .. Colors.reset
     })
-    ao.send({
-      Target = ao.id,
-      Event = "Mint",
-      Quantity = msg.Quantity,
-      TotalSupply = TotalSupply
-    })
     Events.mint(msg.Quantity, msg.From)
   else
     ao.send({


### PR DESCRIPTION
On mint, burn and transfer, emit events that facilitate data aggregation via the gateway.

Solves https://github.com/permaweb/aos/issues/312