### PR TITLE
feat(aos): save input history after exiting a session #329

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import chalk from 'chalk'
 import path from 'path'
 import { errors } from './errors.js'
 import * as url from 'url'
+import process from 'node:process';
 
 import { of, fromPromise, Rejected, Resolved } from 'hyper-async'
 
@@ -37,6 +38,7 @@ import { help, replHelp } from './services/help.js'
 import { list } from './services/list.js'
 import { patch } from './commands/patch.js'
 import * as os from './commands/os.js'
+import { readHistory, writeHistory } from './services/history-service.js'
 
 const argv = minimist(process.argv.slice(2))
 
@@ -83,7 +85,6 @@ if (argv['module'] && argv['module'].length === 43) {
 }
 
 let cron = null
-let history = []
 
 if (argv['watch'] && argv['watch'].length === 43) {
   live(argv['watch'], true).then(res => {
@@ -127,6 +128,8 @@ if (!argv['watch']) {
       let editorMode = false
       let editorData = ""
       let editorPrompt = ""
+
+      let history = readHistory(id)
 
       if (luaData.length > 0 && argv['load']) {
         const spinner = ora({
@@ -427,6 +430,15 @@ if (!argv['watch']) {
         rl.prompt(true)
         return
       })
+
+      process.on('SIGINT', function () {
+        // save the input history when the user exits
+        if (id) {
+          writeHistory(id, history)
+        }
+        process.exit(0)
+      })
+    
       //}
 
       //repl()

--- a/src/services/history-service.js
+++ b/src/services/history-service.js
@@ -1,6 +1,10 @@
 import fs from 'fs';
+import path from 'path';
+import os from 'os';
 
-const historyFilePath = (processId) => `${processId}.history`;
+const historyFilePath = (processId) => {
+    return path.join(os.homedir(), `.${processId}.history`);
+};
 
 export const readHistory = (processId) => {
   const filePath = historyFilePath(processId);

--- a/src/services/history-service.js
+++ b/src/services/history-service.js
@@ -1,0 +1,22 @@
+import fs from 'fs';
+
+const historyFilePath = (processId) => `${processId}.history`;
+
+export const readHistory = (processId) => {
+  const filePath = historyFilePath(processId);
+  if (fs.existsSync(filePath)) {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  }
+  return [];
+};
+
+export const writeHistory = (processId, history) => {
+    const filePath = historyFilePath(processId);
+
+    try {
+        const historyToSave = history.slice(-100);  // Only save the last 100 commands
+        fs.writeFileSync(filePath, JSON.stringify(historyToSave, null, 2));
+    } catch (err) {
+        console.error('Error writing history file:', err);
+    }
+};


### PR DESCRIPTION
Currently the input history for a session is saved, where a user can us the up arrow key to cycle through previous inputs. 

This PR is to save the 100 most recent history items in order to give access to them after the session is closed and restarted. 