### PR TITLE
fix: error when loading lua file with modules using the --load flag

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -498,7 +498,7 @@ async function connect(jwk, id) {
 }
 
 async function handleLoadArgs(jwk, id) {
-  const loadCode = checkLoadArgs().map(f => `.load ${f}`).map(load).join('\n')
+  const loadCode = checkLoadArgs().map(f => `.load ${f}`).map(line => load(line)[0]).join('\n')
   if (loadCode) {
     const spinner = ora({
       spinner: 'dots',


### PR DESCRIPTION
## **Problem**
Loading a lua file with modules using the --load flag will have the modules appended as string to the end of the lua file.  

Example:
<img width="884" alt="Screenshot 2024-09-09 at 15 43 27" src="https://github.com/user-attachments/assets/5efdb47c-8265-4f59-bfd0-09790ff6354f">

## **Fix**
Updating the `handleLoadArgs` function to only map the lua code fixes the problem