### PR TITLE
Support pattern specs in `Handlers.utils.continue()`

### DIFF
--- a/process/handlers-utils.lua
+++ b/process/handlers-utils.lua
@@ -44,13 +44,12 @@ function _utils.reply(input)
   end
 end
 
-function _utils.continue(fn)
-  assert(type(fn) == 'function', 'invalid arguments: (fn : function)')
+function _utils.continue(pattern)
   return function (msg)
-    local patternResult = fn(msg)
+    local match = _.matchesSpec(msg, pattern)
 
-    if not patternResult or patternResult == 0 or patternResult == "skip" then
-      return patternResult
+    if not match or match == 0 or match == "skip" then
+      return match
     end
     return 1
   end

--- a/process/handlers-utils.md
+++ b/process/handlers-utils.md
@@ -48,11 +48,11 @@ Sends a reply to the sender of a message. The reply can be a simple string or a 
 
 - **Returns:** Function that takes a message object and sends the specified reply.
 
-### continue(fn)
-Inverts the provided pattern matching function's result if it matches, so that it continues execution with the next matching handler.
+### continue(pattern)
+Inverts the provided pattern's result if it matches, so that it continues execution with the next matching handler.
 
 - **Parameters:**
-  - `fn` (function): Pattern matching function that returns `"skip"`, `false` or `0` if it does not match.
+  - `pattern` (function|table): Pattern to match
 
 - **Returns:** Function that executes the pattern matching function and returns `1` (continue), so that the execution of handlers continues.
 


### PR DESCRIPTION
Right now there is no way to easily allow continuing execution if you use pattern specs in aos. Until now, the `Handlers.utils.continue()` shortcut function only supported pattern matching functions as input, this update extends this to the following:

```lua
Handlers.add(
  "test-action-that-continues",
  Handlers.utils.continue({ Action = "Some-Action" }),
  some.actionHandler
)
```