### PR TITLE
fix(weavedrive): if no gql results, return 0

### DIFF
--- a/extensions/weavedrive/client/main.lua
+++ b/extensions/weavedrive/client/main.lua
@@ -50,9 +50,6 @@ function drive.getDataItem(txId)
   if not file then
     return nil, "File not found!"
   end
-  if file == 'GQL Not Found!' then
-    return nil, 'GraphQL not Found!'
-  end
   local contents = file:read(
     file:seek('end')
   )

--- a/extensions/weavedrive/test/index.test.js
+++ b/extensions/weavedrive/test/index.test.js
@@ -203,6 +203,25 @@ return result
   assert.equal(data.block.height, 1290333)
 })
 
+test('read data item tx, no result', async () => {
+  const handle = await AoLoader(wasm, options)
+  const result = await handle(memory, {
+    ...Msg,
+    Data: `
+local address = 'foo-address'
+local results = {}
+local drive = require('WeaveDrive')
+local result = drive.getDataItem(address)
+
+return result
+    `
+  }, { Process, Module })
+
+  memory = result.Memory
+  console.log({ result })
+  assert.equal(result.Output.data, '')
+})
+
 test('read data item tx, no gql', async () => {
   const handle = await AoLoader(wasm, {
     ...options,


### PR DESCRIPTION
Before, if GQL query returned no results (invalid tx), then would throw error (node is undefined). Now, return 0.