### PR TITLE
fix(aos): only remove handler if name matches

### DIFF
--- a/process/handlers.lua
+++ b/process/handlers.lua
@@ -235,7 +235,9 @@ function handlers.remove(name)
   end
 
   local idx = findIndexByProp(handlers.list, "name", name)
-  table.remove(handlers.list, idx)
+  if idx ~= nil and idx > 0 then
+    table.remove(handlers.list, idx)
+  end
   
 end
 


### PR DESCRIPTION
If nil is passed as index to table.remove, it removes the last element. Now, only call if idx exists.

https://www.lua.org/pil/19.2.html