### PR TITLE
WIP: get program state and source code

### DIFF
--- a/process/ant-state.json
+++ b/process/ant-state.json
@@ -1,0 +1,1437 @@
+{
+  "packages": {
+    ".crypto.util.hex": {
+      "stringToHex": ".crypto.util.hex",
+      "hexToString": ".crypto.util.hex"
+    },
+    ".process": {
+      "_version": "2.0.0",
+      "handle": ".process"
+    },
+    ".common.records": {
+      "getRecords": "function records.getRecords()\n\treturn json.encode(Records)\nend\n",
+      "setRecord": "function records.setRecord(name, transactionId, ttlSeconds)\n\tlocal nameValidity, nameValidityError = pcall(utils.validateUndername, name)\n\tassert(nameValidity ~= false, nameValidityError)\n\tlocal targetIdValidity, targetValidityError = pcall(utils.validateArweaveId, transactionId)\n\tassert(targetIdValidity ~= false, targetValidityError)\n\tlocal ttlSecondsValidity, ttlValidityError = pcall(utils.validateTTLSeconds, ttlSeconds)\n\tassert(ttlSecondsValidity ~= false, ttlValidityError)\n\n\tlocal recordsCount = #Records\n\n\tif recordsCount >= 10000 then\n\t\terror(\"Max records limit of 10,000 reached, please delete some records to make space\")\n\tend\n\n\tRecords[name] = {\n\t\ttransactionId = transactionId,\n\t\tttlSeconds = ttlSeconds,\n\t}\n\n\treturn json.encode({\n\t\ttransactionId = transactionId,\n\t\tttlSeconds = ttlSeconds,\n\t})\nend\n",
+      "removeRecord": "function records.removeRecord(name)\n\tlocal nameValidity, nameValidityError = pcall(utils.validateUndername, name)\n\tassert(nameValidity ~= false, nameValidityError)\n\tRecords[name] = nil\n\treturn json.encode({ message = \"Record deleted\" })\nend\n",
+      "getRecord": "function records.getRecord(name)\n\tutils.validateUndername(name)\n\tassert(Records[name] ~= nil, \"Record does not exist\")\n\n\treturn json.encode(Records[name])\nend\n"
+    },
+    "debug": {
+      "setlocal": "",
+      "gethook": "",
+      "setuservalue": "",
+      "getlocal": "",
+      "debug": "",
+      "getregistry": "",
+      "getuservalue": "",
+      "getmetatable": "",
+      "upvaluejoin": "",
+      "getupvalue": "",
+      "getinfo": "",
+      "upvalueid": "",
+      "sethook": "",
+      "setmetatable": "",
+      "setupvalue": "",
+      "traceback": ""
+    },
+    ".crypto.cipher.morus": {
+      "decrypt": ".crypto.cipher.morus",
+      "variant": "Morus-1280",
+      "encrypt": ".crypto.cipher.morus",
+      "state_update": ".crypto.cipher.morus",
+      "key_size": 32,
+      "nonce_size": 16
+    },
+    ".common.main": {
+      "init": "function ant.init()\n\t-- main.lua\n\t-- utils\n\tlocal json = require(\".common.json\")\n\tlocal utils = require(\".common.utils\")\n\tlocal camel = utils.camelCase\n\t-- spec modules\n\tlocal balances = require(\".common.balances\")\n\tlocal initialize = require(\".common.initialize\")\n\tlocal records = require(\".common.records\")\n\tlocal controllers = require(\".common.controllers\")\n\n\tOwner = Owner or ao.env.Process.Owner\n\tBalances = Balances or { [Owner] = 1 }\n\tControllers = Controllers or { Owner }\n\n\tName = Name or \"Arweave Name Token\"\n\tTicker = Ticker or \"ANT\"\n\tLogo = Logo or \"Sie_26dvgyok0PZD_-iQAFOhOd5YxDTkczOLoqTTL_A\"\n\tDenomination = Denomination or 0\n\tTotalSupply = TotalSupply or 1\n\tInitialized = Initialized or false\n\t-- INSERT placeholder used by build script to inject the appropriate ID\n\tSourceCodeTxId = SourceCodeTxId or \"__INSERT_SOURCE_CODE_ID__\"\n\tAntRegistryId = AntRegistryId or ao.env.Process.Tags[\"ANT-Registry-Id\"] or nil\n\n\tlocal ActionMap = {\n\t\t-- write\n\t\tAddController = \"Add-Controller\",\n\t\tRemoveController = \"Remove-Controller\",\n\t\tSetRecord = \"Set-Record\",\n\t\tRemoveRecord = \"Remove-Record\",\n\t\tSetName = \"Set-Name\",\n\t\tSetTicker = \"Set-Ticker\",\n\t\t--- initialization method for bootstrapping the contract from other platforms ---\n\t\tInitializeState = \"Initialize-State\",\n\t\t-- read\n\t\tControllers = \"Controllers\",\n\t\tRecord = \"Record\",\n\t\tRecords = \"Records\",\n\t\tState = \"State\",\n\t\tEvolve = \"Evolve\",\n\t}\n\n\tlocal TokenSpecActionMap = {\n\t\tInfo = \"Info\",\n\t\tBalances = \"Balances\",\n\t\tBalance = \"Balance\",\n\t\tTransfer = \"Transfer\",\n\t\tTotalSupply = \"Total-Supply\",\n\t\tCreditNotice = \"Credit-Notice\",\n\t\t-- not implemented\n\t\tMint = \"Mint\",\n\t\tBurn = \"Burn\",\n\t}\n\n\tHandlers.add(\n\t\tcamel(TokenSpecActionMap.Transfer),\n\t\tutils.hasMatchingTag(\"Action\", TokenSpecActionMap.Transfer),\n\t\tfunction(msg)\n\t\t\tlocal recipient = msg.Tags.Recipient\n\t\t\tlocal function checkAssertions()\n\t\t\t\tutils.validateOwner(msg.From)\n\t\t\tend\n\n\t\t\tlocal inputStatus, inputResult = pcall(checkAssertions)\n\n\t\t\tif not inputStatus then\n\t\t\t\tao.send({\n\t\t\t\t\tTarget = msg.From,\n\t\t\t\t\tTags = { Action = \"Invalid-Transfer-Notice\", Error = \"Transfer-Error\" },\n\t\t\t\t\tData = tostring(inputResult),\n\t\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t\t})\n\t\t\t\treturn\n\t\t\tend\n\t\t\tlocal transferStatus, transferResult = pcall(balances.transfer, recipient)\n\n\t\t\tif not transferStatus then\n\t\t\t\tao.send({\n\t\t\t\t\tTarget = msg.From,\n\t\t\t\t\tTags = { Action = \"Invalid-Transfer-Notice\", Error = \"Transfer-Error\" },\n\t\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t\t\tData = tostring(transferResult),\n\t\t\t\t})\n\t\t\t\treturn\n\t\t\telseif not msg.Cast then\n\t\t\t\tao.send(utils.notices.debit(msg))\n\t\t\t\tao.send(utils.notices.credit(msg))\n\t\t\t\tutils.notices.notifyState(msg, AntRegistryId)\n\t\t\t\treturn\n\t\t\tend\n\t\t\tao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tData = transferResult,\n\t\t\t})\n\t\t\tutils.notices.notifyState(msg, AntRegistryId)\n\t\tend\n\t)\n\n\tHandlers.add(\n\t\tcamel(TokenSpecActionMap.Balance),\n\t\tutils.hasMatchingTag(\"Action\", TokenSpecActionMap.Balance),\n\t\tfunction(msg)\n\t\t\tlocal balStatus, balRes = pcall(balances.balance, msg.Tags.Recipient or msg.From)\n\t\t\tif not balStatus then\n\t\t\t\tao.send({\n\t\t\t\t\tTarget = msg.From,\n\t\t\t\t\tTags = { Action = \"Invalid-Balance-Notice\", Error = \"Balance-Error\" },\n\t\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t\t\tData = tostring(balRes),\n\t\t\t\t})\n\t\t\telse\n\t\t\t\tao.send({\n\t\t\t\t\tTarget = msg.From,\n\t\t\t\t\tAction = \"Balance-Notice\",\n\t\t\t\t\tBalance = tostring(balRes),\n\t\t\t\t\tTicker = Ticker,\n\t\t\t\t\tAddress = msg.Tags.Recipient or msg.From,\n\t\t\t\t\tData = balRes,\n\t\t\t\t})\n\t\t\tend\n\t\tend\n\t)\n\n\tHandlers.add(\n\t\tcamel(TokenSpecActionMap.Balances),\n\t\tutils.hasMatchingTag(\"Action\", TokenSpecActionMap.Balances),\n\t\tfunction(msg)\n\t\t\tao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tAction = \"Balances-Notice\",\n\t\t\t\tData = balances.balances(),\n\t\t\t})\n\t\tend\n\t)\n\n\tHandlers.add(\n\t\tcamel(TokenSpecActionMap.TotalSupply),\n\t\tutils.hasMatchingTag(\"Action\", TokenSpecActionMap.TotalSupply),\n\t\tfunction(msg)\n\t\t\tassert(msg.From ~= ao.id, \"Cannot call Total-Supply from the same process!\")\n\n\t\t\tao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tAction = \"Total-Supply-Notice\",\n\t\t\t\tData = TotalSupply,\n\t\t\t\tTicker = Ticker,\n\t\t\t})\n\t\tend\n\t)\n\n\tHandlers.add(camel(TokenSpecActionMap.Info), utils.hasMatchingTag(\"Action\", TokenSpecActionMap.Info), function(msg)\n\t\tlocal info = {\n\t\t\tName = Name,\n\t\t\tTicker = Ticker,\n\t\t\t[\"Total-Supply\"] = tostring(TotalSupply),\n\t\t\tLogo = Logo,\n\t\t\tDenomination = tostring(Denomination),\n\t\t\tOwner = Owner,\n\t\t\tHandlers = utils.getHandlerNames(Handlers),\n\t\t\t[\"Source-Code-TX-ID\"] = SourceCodeTxId,\n\t\t}\n\t\tao.send({\n\t\t\tTarget = msg.From,\n\t\t\tAction = \"Info-Notice\",\n\t\t\tTags = info,\n\t\t\tData = json.encode(info),\n\t\t})\n\tend)\n\n\t-- ActionMap (ANT Spec)\n\n\tHandlers.add(camel(ActionMap.AddController), utils.hasMatchingTag(\"Action\", ActionMap.AddController), function(msg)\n\t\tlocal assertHasPermission, permissionErr = pcall(utils.assertHasPermission, msg.From)\n\t\tif assertHasPermission == false then\n\t\t\treturn ao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tAction = \"Invalid-Add-Controller-Notice\",\n\t\t\t\tError = \"Add-Controller-Error\",\n\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t\tData = permissionErr,\n\t\t\t})\n\t\tend\n\t\tlocal controllerStatus, controllerRes = pcall(controllers.setController, msg.Tags.Controller)\n\t\tif not controllerStatus then\n\t\t\tao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tAction = \"Invalid-Add-Controller-Notice\",\n\t\t\t\tError = \"Add-Controller-Error\",\n\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t\tData = controllerRes,\n\t\t\t})\n\t\t\treturn\n\t\tend\n\t\tao.send({ Target = msg.From, Action = \"Add-Controller-Notice\", Data = controllerRes })\n\t\tutils.notices.notifyState(msg, AntRegistryId)\n\tend)\n\n\tHandlers.add(\n\t\tcamel(ActionMap.RemoveController),\n\t\tutils.hasMatchingTag(\"Action\", ActionMap.RemoveController),\n\t\tfunction(msg)\n\t\t\tlocal assertHasPermission, permissionErr = pcall(utils.assertHasPermission, msg.From)\n\t\t\tif assertHasPermission == false then\n\t\t\t\treturn ao.send({\n\t\t\t\t\tTarget = msg.From,\n\t\t\t\t\tAction = \"Invalid-Remove-Controller-Notice\",\n\t\t\t\t\tData = permissionErr,\n\t\t\t\t\tError = \"Remove-Controller-Error\",\n\t\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t\t})\n\t\t\tend\n\t\t\tlocal removeStatus, removeRes = pcall(controllers.removeController, msg.Tags.Controller)\n\t\t\tif not removeStatus then\n\t\t\t\tao.send({\n\t\t\t\t\tTarget = msg.From,\n\t\t\t\t\tAction = \"Invalid-Remove-Controller-Notice\",\n\t\t\t\t\tData = removeRes,\n\t\t\t\t\tError = \"Remove-Controller-Error\",\n\t\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t\t})\n\t\t\t\treturn\n\t\t\tend\n\n\t\t\tao.send({ Target = msg.From, Action = \"Remove-Controller-Notice\", Data = removeRes })\n\t\t\tutils.notices.notifyState(msg, AntRegistryId)\n\t\tend\n\t)\n\n\tHandlers.add(camel(ActionMap.Controllers), utils.hasMatchingTag(\"Action\", ActionMap.Controllers), function(msg)\n\t\tao.send({ Target = msg.From, Action = \"Controllers-Notice\", Data = controllers.getControllers() })\n\tend)\n\n\tHandlers.add(camel(ActionMap.SetRecord), utils.hasMatchingTag(\"Action\", ActionMap.SetRecord), function(msg)\n\t\tlocal assertHasPermission, permissionErr = pcall(utils.assertHasPermission, msg.From)\n\t\tif assertHasPermission == false then\n\t\t\treturn ao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tAction = \"Invalid-Set-Record-Notice\",\n\t\t\t\tData = permissionErr,\n\t\t\t\tError = \"Set-Record-Error\",\n\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t})\n\t\tend\n\t\tlocal tags = msg.Tags\n\t\tlocal name, transactionId, ttlSeconds =\n\t\t\tstring.lower(tags[\"Sub-Domain\"]), tags[\"Transaction-Id\"], tonumber(tags[\"TTL-Seconds\"])\n\n\t\tlocal setRecordStatus, setRecordResult = pcall(records.setRecord, name, transactionId, ttlSeconds)\n\t\tif not setRecordStatus then\n\t\t\tao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tAction = \"Invalid-Set-Record-Notice\",\n\t\t\t\tData = setRecordResult,\n\t\t\t\tError = \"Set-Record-Error\",\n\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t})\n\t\t\treturn\n\t\tend\n\n\t\tao.send({ Target = msg.From, Action = \"Set-Record-Notice\", Data = setRecordResult })\n\tend)\n\n\tHandlers.add(camel(ActionMap.RemoveRecord), utils.hasMatchingTag(\"Action\", ActionMap.RemoveRecord), function(msg)\n\t\tlocal assertHasPermission, permissionErr = pcall(utils.assertHasPermission, msg.From)\n\t\tif assertHasPermission == false then\n\t\t\treturn ao.send({ Target = msg.From, Action = \"Invalid-Remove-Record-Notice\", Data = permissionErr })\n\t\tend\n\t\tlocal name = string.lower(msg.Tags[\"Sub-Domain\"])\n\t\tlocal removeRecordStatus, removeRecordResult = pcall(records.removeRecord, name)\n\t\tif not removeRecordStatus then\n\t\t\tao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tAction = \"Invalid-Remove-Record-Notice\",\n\t\t\t\tData = removeRecordResult,\n\t\t\t\tError = \"Remove-Record-Error\",\n\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t})\n\t\telse\n\t\t\tao.send({ Target = msg.From, Data = removeRecordResult })\n\t\tend\n\tend)\n\n\tHandlers.add(camel(ActionMap.Record), utils.hasMatchingTag(\"Action\", ActionMap.Record), function(msg)\n\t\tlocal name = string.lower(msg.Tags[\"Sub-Domain\"])\n\t\tlocal nameStatus, nameRes = pcall(records.getRecord, name)\n\t\tif not nameStatus then\n\t\t\tao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tAction = \"Invalid-Record-Notice\",\n\t\t\t\tData = nameRes,\n\t\t\t\tError = \"Record-Error\",\n\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t})\n\t\t\treturn\n\t\tend\n\n\t\tlocal recordNotice = {\n\t\t\tTarget = msg.From,\n\t\t\tAction = \"Record-Notice\",\n\t\t\tName = name,\n\t\t\tData = nameRes,\n\t\t}\n\n\t\t-- Add forwarded tags to the credit and debit notice messages\n\t\tfor tagName, tagValue in pairs(msg) do\n\t\t\t-- Tags beginning with \"X-\" are forwarded\n\t\t\tif string.sub(tagName, 1, 2) == \"X-\" then\n\t\t\t\trecordNotice[tagName] = tagValue\n\t\t\tend\n\t\tend\n\n\t\t-- Send Record-Notice\n\t\tao.send(recordNotice)\n\tend)\n\n\tHandlers.add(camel(ActionMap.Records), utils.hasMatchingTag(\"Action\", ActionMap.Records), function(msg)\n\t\tlocal records = records.getRecords()\n\n\t\t-- Credit-Notice message template, that is sent to the Recipient of the transfer\n\t\tlocal recordsNotice = {\n\t\t\tTarget = msg.From,\n\t\t\tAction = \"Records-Notice\",\n\t\t\tData = records,\n\t\t}\n\n\t\t-- Add forwarded tags to the records notice messages\n\t\tfor tagName, tagValue in pairs(msg) do\n\t\t\t-- Tags beginning with \"X-\" are forwarded\n\t\t\tif string.sub(tagName, 1, 2) == \"X-\" then\n\t\t\t\trecordsNotice[tagName] = tagValue\n\t\t\tend\n\t\tend\n\n\t\t-- Send Records-Notice\n\t\tao.send(recordsNotice)\n\tend)\n\n\tHandlers.add(camel(ActionMap.SetName), utils.hasMatchingTag(\"Action\", ActionMap.SetName), function(msg)\n\t\tlocal assertHasPermission, permissionErr = pcall(utils.assertHasPermission, msg.From)\n\t\tif assertHasPermission == false then\n\t\t\treturn ao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tAction = \"Invalid-Set-Name-Notice\",\n\t\t\t\tData = permissionErr,\n\t\t\t\tError = \"Set-Name-Error\",\n\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t})\n\t\tend\n\t\tlocal nameStatus, nameRes = pcall(balances.setName, msg.Tags.Name)\n\t\tif not nameStatus then\n\t\t\tao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tAction = \"Invalid-Set-Name-Notice\",\n\t\t\t\tData = nameRes,\n\t\t\t\tError = \"Set-Name-Error\",\n\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t})\n\t\t\treturn\n\t\tend\n\t\tao.send({ Target = msg.From, Action = \"Set-Name-Notice\", Data = nameRes })\n\tend)\n\n\tHandlers.add(camel(ActionMap.SetTicker), utils.hasMatchingTag(\"Action\", ActionMap.SetTicker), function(msg)\n\t\tlocal assertHasPermission, permissionErr = pcall(utils.assertHasPermission, msg.From)\n\t\tif assertHasPermission == false then\n\t\t\treturn ao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tAction = \"Invalid-Set-Ticker-Notice\",\n\t\t\t\tData = permissionErr,\n\t\t\t\tError = \"Set-Ticker-Error\",\n\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t})\n\t\tend\n\t\tlocal tickerStatus, tickerRes = pcall(balances.setTicker, msg.Tags.Ticker)\n\t\tif not tickerStatus then\n\t\t\tao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tAction = \"Invalid-Set-Ticker-Notice\",\n\t\t\t\tData = tickerRes,\n\t\t\t\tError = \"Set-Ticker-Error\",\n\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t})\n\t\t\treturn\n\t\tend\n\n\t\tao.send({ Target = msg.From, Action = \"Set-Ticker-Notice\", Data = tickerRes })\n\tend)\n\n\tHandlers.add(\n\t\tcamel(ActionMap.InitializeState),\n\t\tutils.hasMatchingTag(\"Action\", ActionMap.InitializeState),\n\t\tfunction(msg)\n\t\t\tassert(msg.From == Owner, \"Only the owner can initialize the state\")\n\t\t\tlocal initStatus, result = pcall(initialize.initializeANTState, msg.Data)\n\n\t\t\tif not initStatus then\n\t\t\t\tao.send({\n\t\t\t\t\tTarget = msg.From,\n\t\t\t\t\tAction = \"Invalid-Initialize-State-Notice\",\n\t\t\t\t\tData = result,\n\t\t\t\t\tError = \"Initialize-State-Error\",\n\t\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t\t})\n\t\t\t\treturn\n\t\t\telse\n\t\t\t\tao.send({ Target = msg.From, Action = \"Initialize-State-Notice\", Data = result })\n\t\t\t\tutils.notices.notifyState(msg, AntRegistryId)\n\t\t\tend\n\t\tend\n\t)\n\tHandlers.add(camel(ActionMap.State), utils.hasMatchingTag(\"Action\", ActionMap.State), function(msg)\n\t\tutils.notices.notifyState(msg, msg.From)\n\tend)\n\n\tHandlers.prepend(\n\t\tcamel(ActionMap.Evolve),\n\t\tHandlers.utils.continue(utils.hasMatchingTag(\"Action\", \"Eval\")),\n\t\tfunction(msg)\n\t\t\tlocal srcCodeTxId = msg.Tags[\"Source-Code-TX-ID\"]\n\t\t\tif not srcCodeTxId then\n\t\t\t\treturn\n\t\t\tend\n\n\t\t\tif Owner ~= msg.From then\n\t\t\t\tao.send({\n\t\t\t\t\tTarget = msg.From,\n\t\t\t\t\tAction = \"Invalid-Evolve-Notice\",\n\t\t\t\t\tError = \"Evolve-Error\",\n\t\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t\t\tData = \"Only the Owner [\" .. Owner or \"no owner set\" .. \"] can call Evolve\",\n\t\t\t\t})\n\t\t\t\treturn\n\t\t\tend\n\n\t\t\tlocal srcCodeTxIdStatus, srcCodeTxIdResult = pcall(utils.validateArweaveId, srcCodeTxId)\n\t\t\tif srcCodeTxIdStatus and not srcCodeTxIdStatus then\n\t\t\t\tao.send({\n\t\t\t\t\tTarget = msg.From,\n\t\t\t\t\tAction = \"Invalid-Evolve-Notice\",\n\t\t\t\t\tError = \"Evolve-Error\",\n\t\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t\t\tData = \"Source-Code-TX-ID is required\",\n\t\t\t\t})\n\t\t\t\treturn\n\t\t\tend\n\t\t\tSourceCodeTxId = srcCodeTxId\n\t\tend\n\t)\nend\n"
+    },
+    ".base64": {
+      "makedecoder": ".base64",
+      "decode": ".base64",
+      "encode": ".base64",
+      "makeencoder": ".base64"
+    },
+    ".handlers": {
+      "coroutines": [],
+      "once": ".handlers",
+      "list": {
+        "1": {
+          "pattern": ".handlers-utils",
+          "name": "evolve",
+          "handle": ".handlers"
+        },
+        "2": {
+          "pattern": ".process",
+          "name": "_eval",
+          "handle": ".handlers"
+        },
+        "3": {
+          "pattern": {
+            "Action": "Program-State"
+          },
+          "name": "_programState",
+          "handle": ".handlers"
+        },
+        "4": {
+          "pattern": ".process",
+          "handle": ".handlers",
+          "name": "_boot",
+          "maxRuns": 1
+        },
+        "5": {
+          "pattern": ".process",
+          "name": "_default",
+          "handle": ".handlers"
+        },
+        "6": {
+          "pattern": ".handlers-utils",
+          "name": "transfer",
+          "handle": ".handlers"
+        },
+        "7": {
+          "pattern": ".handlers-utils",
+          "name": "balance",
+          "handle": ".handlers"
+        },
+        "8": {
+          "pattern": ".handlers-utils",
+          "name": "balances",
+          "handle": ".handlers"
+        },
+        "9": {
+          "pattern": ".handlers-utils",
+          "name": "totalSupply",
+          "handle": ".handlers"
+        },
+        "10": {
+          "pattern": ".handlers-utils",
+          "name": "info",
+          "handle": ".handlers"
+        },
+        "11": {
+          "pattern": ".handlers-utils",
+          "name": "addController",
+          "handle": ".handlers"
+        },
+        "12": {
+          "pattern": ".handlers-utils",
+          "name": "removeController",
+          "handle": ".handlers"
+        },
+        "13": {
+          "pattern": ".handlers-utils",
+          "name": "controllers",
+          "handle": ".handlers"
+        },
+        "14": {
+          "pattern": ".handlers-utils",
+          "name": "setRecord",
+          "handle": ".handlers"
+        },
+        "15": {
+          "pattern": ".handlers-utils",
+          "name": "removeRecord",
+          "handle": ".handlers"
+        },
+        "16": {
+          "pattern": ".handlers-utils",
+          "name": "record",
+          "handle": ".handlers"
+        },
+        "17": {
+          "pattern": ".handlers-utils",
+          "name": "records",
+          "handle": ".handlers"
+        },
+        "18": {
+          "pattern": ".handlers-utils",
+          "name": "setName",
+          "handle": ".handlers"
+        },
+        "19": {
+          "pattern": ".handlers-utils",
+          "name": "setTicker",
+          "handle": ".handlers"
+        },
+        "20": {
+          "pattern": ".handlers-utils",
+          "name": "initializeState",
+          "handle": ".handlers"
+        },
+        "21": {
+          "pattern": ".handlers-utils",
+          "name": "state",
+          "handle": ".handlers"
+        }
+      },
+      "before": ".handlers",
+      "onceNonce": 0,
+      "utils": {
+        "hasMatchingTag": ".handlers-utils",
+        "hasMatchingData": ".handlers-utils",
+        "_version": "0.0.2",
+        "hasMatchingTagOf": ".handlers-utils",
+        "reply": ".handlers-utils",
+        "continue": ".handlers-utils"
+      },
+      "receive": ".handlers",
+      "generateResolver": ".handlers",
+      "add": ".handlers",
+      "append": ".handlers",
+      "evaluate": ".handlers",
+      "_version": "0.0.5",
+      "after": ".handlers",
+      "remove": ".handlers",
+      "prepend": ".handlers"
+    },
+    ".crypto.init": {
+      "utils": {
+        "bit": {
+          "arshift": "",
+          "bnot": "",
+          "bxor": "",
+          "bor": "",
+          "btest": "",
+          "lshift": "",
+          "lrotate": "",
+          "extract": "",
+          "band": "",
+          "rrotate": "",
+          "replace": "",
+          "rshift": ""
+        },
+        "stream": {
+          "toString": ".crypto.util.stream",
+          "toHex": ".crypto.util.stream",
+          "toArray": ".crypto.util.stream",
+          "fromString": ".crypto.util.stream",
+          "fromHex": ".crypto.util.stream",
+          "fromArray": ".crypto.util.stream"
+        },
+        "_version": "0.0.1",
+        "array": {
+          "concat": ".crypto.util.array",
+          "readFromQueue": ".crypto.util.array",
+          "toStream": ".crypto.util.array",
+          "fromHex": ".crypto.util.array",
+          "toHex": ".crypto.util.array",
+          "slice": ".crypto.util.array",
+          "fromStream": ".crypto.util.array",
+          "toString": ".crypto.util.array",
+          "permute": ".crypto.util.array",
+          "writeToQueue": ".crypto.util.array",
+          "XOR": ".crypto.util.array",
+          "truncate": ".crypto.util.array",
+          "size": ".crypto.util.array",
+          "substitute": ".crypto.util.array",
+          "fromString": ".crypto.util.array",
+          "copy": ".crypto.util.array"
+        },
+        "hex": "<circular reference>",
+        "queue": ".crypto.util.queue"
+      },
+      "cipher": {
+        "norx": {
+          "variant": "NORX 64-4-1",
+          "nonce_size": 32,
+          "key_size": 32,
+          "decrypt": ".crypto.cipher.norx",
+          "encrypt": ".crypto.cipher.norx"
+        },
+        "issac": {
+          "random": ".crypto.cipher.issac",
+          "getRandomChar": ".crypto.cipher.issac",
+          "encrypt": ".crypto.cipher.issac",
+          "decrypt": ".crypto.cipher.issac",
+          "seedIsaac": ".crypto.cipher.issac",
+          "getRandom": ".crypto.cipher.issac"
+        },
+        "aes": {
+          "encrypt": ".crypto.cipher.aes",
+          "decrypt": ".crypto.cipher.aes"
+        },
+        "morus": "<circular reference>",
+        "_version": "0.0.1"
+      },
+      "random": ".crypto.cipher.issac",
+      "_version": "0.0.1",
+      "kdf": {
+        "_version": "0.0.1",
+        "pbkdf2": ".crypto.kdf.pbkdf2"
+      },
+      "digest": {
+        "sha2_512": ".crypto.digest.sha2_512",
+        "md5": ".crypto.digest.md5",
+        "md4": ".crypto.digest.md4",
+        "sha3_256": "",
+        "sha3_512": "",
+        "sha1": ".crypto.digest.sha1",
+        "keccak256": "",
+        "keccak512": "",
+        "_version": "0.0.1",
+        "md2": ".crypto.digest.md2",
+        "sha2_256": ".crypto.digest.sha2_256",
+        "blake2b": ".crypto.digest.blake2b"
+      },
+      "mac": {
+        "_version": "0.0.1",
+        "createHmac": ".crypto.mac.hmac"
+      }
+    },
+    ".common.initialize": {
+      "initializeANTState": "function initialize.initializeANTState(state)\n\tlocal encoded = json.decode(state)\n\tlocal balances = encoded.balances\n\tlocal controllers = encoded.controllers\n\tlocal records = encoded.records\n\tlocal name = encoded.name\n\tlocal ticker = encoded.ticker\n\tlocal owner = encoded.owner\n\tassert(type(name) == \"string\", \"name must be a string\")\n\tassert(type(ticker) == \"string\", \"ticker must be a string\")\n\tassert(type(balances) == \"table\", \"balances must be a table\")\n\tfor k, v in pairs(balances) do\n\t\tbalances[k] = tonumber(v)\n\tend\n\tassert(type(controllers) == \"table\", \"controllers must be a table\")\n\tassert(type(records) == \"table\", \"records must be a table\")\n\tassert(type(owner) == \"string\", \"owner must be a string\")\n\tfor k, v in pairs(records) do\n\t\tutils.validateUndername(k)\n\t\tassert(type(v) == \"table\", \"records values must be tables\")\n\t\tutils.validateArweaveId(v.transactionId)\n\t\tutils.validateTTLSeconds(v.ttlSeconds)\n\tend\n\n\tName = name\n\tTicker = ticker\n\tBalances = balances\n\tControllers = controllers\n\tRecords = records\n\tInitialized = true\n\tOwner = owner\n\n\treturn json.encode({\n\t\tname = Name,\n\t\tticker = Ticker,\n\t\tbalances = Balances,\n\t\tcontrollers = Controllers,\n\t\trecords = Records,\n\t\towner = Owner,\n\t\tinitialized = Initialized,\n\t})\nend\n",
+      "initializeProcessState": "function initialize.initializeProcessState(msg, env)\n\tErrors = Errors or {}\n\tInbox = Inbox or {}\n\n\t-- temporary fix for Spawn\n\tif not Owner then\n\t\tlocal _from = findObject(env.Process.Tags, \"name\", \"From-Process\")\n\t\tif _from then\n\t\t\tOwner = _from.value\n\t\telse\n\t\t\tOwner = msg.From\n\t\tend\n\tend\n\n\tif not Name then\n\t\tlocal taggedName = findObject(env.Process.Tags, \"name\", \"Name\")\n\t\tif taggedName then\n\t\t\tName = taggedName.value\n\t\telse\n\t\t\tName = \"ANT\"\n\t\tend\n\tend\nend\n"
+    },
+    ".crypto.digest.blake2b": ".crypto.digest.blake2b",
+    ".chance": {
+      "random": ".chance",
+      "seed": ".chance",
+      "integer": ".chance"
+    },
+    ".crypto.util.array": "<circular reference>",
+    ".common.balances": {
+      "setName": "function balances.setName(name)\n\tassert(type(name) == \"string\", \"Name must be a string\")\n\tName = name\n\treturn json.encode({ name = Name })\nend\n",
+      "balance": "function balances.balance(address)\n\tutils.validateArweaveId(address)\n\tlocal balance = Balances[address] or 0\n\treturn balance\nend\n",
+      "balances": "function balances.balances()\n\treturn json.encode(Balances)\nend\n",
+      "walletHasSufficientBalance": "function balances.walletHasSufficientBalance(wallet)\n\treturn Balances[wallet] ~= nil and Balances[wallet] > 0\nend\n",
+      "setTicker": "function balances.setTicker(ticker)\n\tassert(type(ticker) == \"string\", \"Ticker must be a string\")\n\tTicker = ticker\n\treturn json.encode({ ticker = Ticker })\nend\n",
+      "transfer": "function balances.transfer(to)\n\tutils.validateArweaveId(to)\n\tBalances = { [to] = 1 }\n\tOwner = to\n\tControllers = {}\n\treturn json.encode({ [to] = 1 })\nend\n"
+    },
+    ".common.controllers": {
+      "setController": "function controllers.setController(controller)\n\tutils.validateArweaveId(controller)\n\n\tfor _, c in ipairs(Controllers) do\n\t\tassert(c ~= controller, \"Controller already exists\")\n\tend\n\n\ttable.insert(Controllers, controller)\n\treturn json.encode(Controllers)\nend\n",
+      "getControllers": "function controllers.getControllers()\n\treturn json.encode(Controllers)\nend\n",
+      "removeController": "function controllers.removeController(controller)\n\tutils.validateArweaveId(controller)\n\tlocal controllerExists = false\n\n\tfor i, v in ipairs(Controllers) do\n\t\tif v == controller then\n\t\t\ttable.remove(Controllers, i)\n\t\t\tcontrollerExists = true\n\t\t\tbreak\n\t\tend\n\tend\n\n\tassert(controllerExists ~= nil, \"Controller does not exist\")\n\treturn json.encode(Controllers)\nend\n"
+    },
+    "ao": {
+      "removeAssignable": ".assignment",
+      "isAssignable": ".assignment",
+      "reference": 0,
+      "outbox": {
+        "Messages": [],
+        "Spawns": [],
+        "Output": [],
+        "Assignments": []
+      },
+      "sanitize": ".ao",
+      "send": ".process",
+      "result": ".ao",
+      "_version": "0.0.6",
+      "init": ".ao",
+      "spawn": ".process",
+      "authorities": {
+        "1": "BOOP"
+      },
+      "id": "AOS",
+      "normalize": ".ao",
+      "nonExtractableTags": {
+        "1": "Data-Protocol",
+        "2": "Variant",
+        "3": "From-Process",
+        "4": "From-Module",
+        "5": "Type",
+        "6": "From",
+        "7": "Owner",
+        "8": "Anchor",
+        "9": "Target",
+        "10": "Data",
+        "11": "Tags"
+      },
+      "log": ".ao",
+      "isAssignment": "",
+      "assignables": [],
+      "env": {
+        "Process": {
+          "Owner": "FOOBAR",
+          "Id": "AOS",
+          "TagArray": {
+            "1": {
+              "name": "Name",
+              "value": "Thomas"
+            },
+            "2": {
+              "name": "Authority",
+              "value": "BOOP"
+            }
+          },
+          "Tags": {
+            "Name": "Thomas",
+            "Authority": "BOOP"
+          }
+        }
+      },
+      "nonForwardableTags": {
+        "1": "Data-Protocol",
+        "2": "Variant",
+        "3": "From-Process",
+        "4": "From-Module",
+        "5": "Type",
+        "6": "From",
+        "7": "Owner",
+        "8": "Anchor",
+        "9": "Target",
+        "10": "Tags",
+        "11": "TagArray",
+        "12": "Hash-Chain",
+        "13": "Timestamp",
+        "14": "Nonce",
+        "15": "Epoch",
+        "16": "Signature",
+        "17": "Forwarded-By",
+        "18": "Pushed-For",
+        "19": "Read-Only",
+        "20": "Cron",
+        "21": "Block-Height",
+        "22": "Reference",
+        "23": "Id",
+        "24": "Reply-To"
+      },
+      "_module": "",
+      "clearOutbox": ".ao",
+      "assign": ".ao",
+      "addAssignable": ".assignment",
+      "clone": ".ao",
+      "isTrusted": ".ao"
+    },
+    ".crypto.digest.md2": ".crypto.digest.md2",
+    ".crypto.padding.zero": ".crypto.padding.zero",
+    ".crypto.kdf.init": "<circular reference>",
+    "json": {
+      "_version": "0.2.0",
+      "encode": "",
+      "decode": "json"
+    },
+    ".crypto.cipher.mode.ecb": {
+      "Cipher": ".crypto.cipher.mode.ecb",
+      "Decipher": ".crypto.cipher.mode.ecb"
+    },
+    "os": {
+      "tmpname": "",
+      "setlocale": "",
+      "getenv": "",
+      "time": ".process",
+      "rename": "",
+      "execute": "",
+      "difftime": "",
+      "exit": "",
+      "date": "",
+      "remove": "",
+      "clock": ""
+    },
+    ".crypto.cipher.mode.cbc": {
+      "Cipher": ".crypto.cipher.mode.cbc",
+      "Decipher": ".crypto.cipher.mode.cbc"
+    },
+    ".crypto.cipher.mode.ctr": {
+      "Cipher": ".crypto.cipher.mode.ctr",
+      "Decipher": ".crypto.cipher.mode.ctr"
+    },
+    ".crypto.digest.md4": ".crypto.digest.md4",
+    ".crypto.cipher.norx": "<circular reference>",
+    ".crypto.util.queue": ".crypto.util.queue",
+    ".crypto.mac.hmac": {
+      "hmac": ".crypto.mac.hmac",
+      "HMAC": ".crypto.mac.hmac"
+    },
+    "table": {
+      "unpack": "",
+      "insert": "",
+      "pack": "",
+      "remove": "",
+      "sort": "",
+      "move": "",
+      "concat": ""
+    },
+    "utf8": {
+      "charpattern": "[\u0000-�-�][�-�]*",
+      "codepoint": "",
+      "char": "",
+      "offset": "",
+      "len": "",
+      "codes": ""
+    },
+    ".stringify": {
+      "isSimpleArray": ".stringify",
+      "format": ".stringify",
+      "_version": "0.0.1"
+    },
+    ".crypto.cipher.mode.ofb": {
+      "Cipher": ".crypto.cipher.mode.ofb",
+      "Decipher": ".crypto.cipher.mode.ofb"
+    },
+    ".crypto.cipher.issac": "<circular reference>",
+    ".crypto.util.init": "<circular reference>",
+    ".crypto.cipher.mode.cfb": {
+      "Cipher": ".crypto.cipher.mode.cfb",
+      "Decipher": ".crypto.cipher.mode.cfb"
+    },
+    ".ao": "<circular reference>",
+    ".dump": ".dump",
+    ".crypto.cipher.init": "<circular reference>",
+    ".boot": ".boot",
+    ".utils": {
+      "values": ".utils",
+      "propEq": ".utils",
+      "parseValue": ".utils",
+      "map": ".utils",
+      "reverse": ".utils",
+      "reduce": ".utils",
+      "keys": ".utils",
+      "_version": "0.0.5",
+      "find": ".utils",
+      "getProgramState": ".utils",
+      "filter": ".utils",
+      "matchesPattern": ".utils",
+      "prop": ".utils",
+      "compose": ".utils",
+      "concat": ".utils",
+      "parseCoroutine": ".utils",
+      "parseFunctionCode": ".utils",
+      "curry": ".utils",
+      "matchesSpec": ".utils",
+      "includes": ".utils"
+    },
+    "math": {
+      "deg": "",
+      "acos": "",
+      "log10": "",
+      "tan": "",
+      "ldexp": "",
+      "log": "",
+      "atan": "",
+      "sin": "",
+      "asin": "",
+      "abs": "",
+      "exp": "",
+      "ult": "",
+      "type": "",
+      "min": "",
+      "sqrt": "",
+      "sinh": "",
+      "tanh": "",
+      "cos": "",
+      "huge": "inf",
+      "random": ".process",
+      "atan2": "",
+      "cosh": "",
+      "max": "",
+      "frexp": "",
+      "tointeger": "",
+      "pi": 3.1415926535898,
+      "modf": "",
+      "fmod": "",
+      "rad": "",
+      "mininteger": -9223372036854800000,
+      "randomseed": "",
+      "floor": "",
+      "ceil": "",
+      "maxinteger": 9223372036854800000,
+      "pow": ""
+    },
+    ".crypto.digest.init": "<circular reference>",
+    ".pretty": {
+      "_version": "0.0.1",
+      "tprint": ".pretty"
+    },
+    ".crypto.digest.sha2_256": {
+      "sha2_256": ".crypto.digest.sha2_256",
+      "SHA2_256": ".crypto.digest.sha2_256"
+    },
+    ".crypto.digest.md5": ".crypto.digest.md5",
+    "bit32": "<circular reference>",
+    ".crypto.digest.sha2_512": ".crypto.digest.sha2_512",
+    ".default": ".default",
+    "coroutine": {
+      "wrap": "",
+      "create": "",
+      "running": "",
+      "resume": "",
+      "status": "",
+      "yield": "",
+      "isyieldable": ""
+    },
+    ".common.constants": {
+      "MIN_TTL_SECONDS": 900,
+      "MAX_UNDERNAME_LENGTH": 61,
+      "UNDERNAME_DOES_NOT_EXIST_MESSAGE": "Name does not exist in the ANT!",
+      "UNDERNAME_REGEXP": "^(?:@|[a-zA-Z0-9][a-zA-Z0-9-_]{0,59}[a-zA-Z0-9])$",
+      "INVALID_ARWEAVE_ID_MESSAGE": "Invalid Arweave ID",
+      "MAX_TTL_SECONDS": 3600,
+      "ARWEAVE_ID_REGEXP": "^[a-zA-Z0-9-_]{43}$",
+      "INVALID_TTL_MESSAGE": "Invalid TTL. TLL must be an integer between 900 and 3600 seconds"
+    },
+    ".crypto.util.bit": "<circular reference>",
+    ".crypto.cipher.aes256": {
+      "encrypt": ".crypto.cipher.aes256",
+      "blockSize": 16,
+      "decrypt": ".crypto.cipher.aes256"
+    },
+    ".crypto.digest.sha1": {
+      "sha1": ".crypto.digest.sha1",
+      "SHA1": ".crypto.digest.sha1"
+    },
+    ".crypto.cipher.aes": "<circular reference>",
+    "io": {
+      "lines": "",
+      "flush": "",
+      "open": "",
+      "stderr": "<userdata>",
+      "write": "",
+      "read": "",
+      "input": "",
+      "type": "",
+      "close": "",
+      "popen": "",
+      "output": "",
+      "tmpfile": "",
+      "stdout": "<userdata>",
+      "stdin": "<userdata>"
+    },
+    ".crypto.util.stream": "<circular reference>",
+    ".eval": ".eval",
+    "string": {
+      "byte": "",
+      "char": "",
+      "gmatch": "",
+      "packsize": "",
+      "lower": "",
+      "dump": "",
+      "reverse": "",
+      "unpack": "",
+      "find": "",
+      "rep": "",
+      "upper": "",
+      "match": "",
+      "sub": "",
+      "pack": "",
+      "format": "",
+      "len": "",
+      "gsub": ""
+    },
+    ".crypto.mac.init": "<circular reference>",
+    ".handlers-utils": "<circular reference>",
+    ".crypto.cipher.aes128": {
+      "encrypt": ".crypto.cipher.aes128",
+      "blockSize": 16,
+      "decrypt": ".crypto.cipher.aes128"
+    },
+    ".assignment": {
+      "_version": "0.1.0",
+      "init": ".assignment"
+    },
+    ".crypto.digest.sha3": {
+      "sha3_512": "",
+      "keccak256": "",
+      "sha3_256": "",
+      "keccak512": ""
+    },
+    ".crypto.kdf.pbkdf2": {
+      "PBKDF2": ".crypto.kdf.pbkdf2",
+      "pbkdf2": ".crypto.kdf.pbkdf2"
+    },
+    ".common.utils": {
+      "getHandlerNames": "function utils.getHandlerNames(handlers)\n\tlocal names = {}\n\tfor _, handler in ipairs(handlers.list) do\n\t\ttable.insert(names, handler.name)\n\tend\n\treturn names\nend\n",
+      "values": "utils.values = function(t)\n\tassert(type(t) == \"table\", \"argument needs to be a table\")\n\tlocal values = {}\n\tfor _, value in pairs(t) do\n\t\ttable.insert(values, value)\n\tend\n\treturn values\nend\n",
+      "validateArweaveId": "function utils.validateArweaveId(id)\n\tlocal valid = string.match(id, constants.ARWEAVE_ID_REGEXP) == nil\n\n\tassert(valid == true, constants.INVALID_ARWEAVE_ID_MESSAGE)\nend\n",
+      "hasMatchingTag": "function utils.hasMatchingTag(tag, value)\n\treturn Handlers.utils.hasMatchingTag(tag, value)\nend\n",
+      "propEq": "\treturn function(...)\n\t\tlocal args = { ... }\n\n\t\tif #args >= arity then\n\t\t\treturn fn(table.unpack(args))\n\t\telse\n\t\t\treturn utils.curry(function(...)\n\t\t\t\treturn fn(table.unpack(args), ...)\n\t\t\tend, arity - #args)\n\t\tend\n\tend\n",
+      "_version": "0.0.1",
+      "map": "\treturn function(...)\n\t\tlocal args = { ... }\n\n\t\tif #args >= arity then\n\t\t\treturn fn(table.unpack(args))\n\t\telse\n\t\t\treturn utils.curry(function(...)\n\t\t\t\treturn fn(table.unpack(args), ...)\n\t\t\tend, arity - #args)\n\t\tend\n\tend\n",
+      "reverse": "utils.reverse = function(data)\n\tassert(type(data) == \"table\", \"argument needs to be a table that is an array\")\n\treturn utils.reduce(function(result, v, i)\n\t\tresult[#data - i + 1] = v\n\t\treturn result\n\tend, {}, data)\nend\n",
+      "compose": "\treturn function(...)\n\t\tlocal args = { ... }\n\n\t\tif #args >= arity then\n\t\t\treturn fn(table.unpack(args))\n\t\telse\n\t\t\treturn utils.curry(function(...)\n\t\t\t\treturn fn(table.unpack(args), ...)\n\t\t\tend, arity - #args)\n\t\tend\n\tend\n",
+      "camelCase": "function utils.camelCase(str)\n\t-- Remove any leading or trailing spaces\n\tstr = string.gsub(str, \"^%s*(.-)%s*$\", \"%1\")\n\n\t-- Convert PascalCase to camelCase\n\tstr = string.gsub(str, \"^%u\", string.lower)\n\n\t-- Handle kebab-case, snake_case, and space-separated words\n\tstr = string.gsub(str, \"[-_%s](%w)\", function(s)\n\t\treturn string.upper(s)\n\tend)\n\n\treturn str\nend\n",
+      "notices": {
+        "credit": "function utils.notices.credit(msg)\n\tlocal notice = {\n\t\tTarget = msg.Recipient,\n\t\tAction = \"Credit-Notice\",\n\t\tSender = msg.From,\n\t\tQuantity = tostring(1),\n\t}\n\tfor tagName, tagValue in pairs(msg) do\n\t\t-- Tags beginning with \"X-\" are forwarded\n\t\tif string.sub(tagName, 1, 2) == \"X-\" then\n\t\t\tnotice[tagName] = tagValue\n\t\tend\n\tend\n\n\treturn notice\nend\n",
+        "debit": "function utils.notices.debit(msg)\n\tlocal notice = {\n\t\tTarget = msg.From,\n\t\tAction = \"Debit-Notice\",\n\t\tRecipient = msg.Recipient,\n\t\tQuantity = tostring(1),\n\t}\n\t-- Add forwarded tags to the credit and debit notice messages\n\tfor tagName, tagValue in pairs(msg) do\n\t\t-- Tags beginning with \"X-\" are forwarded\n\t\tif string.sub(tagName, 1, 2) == \"X-\" then\n\t\t\tnotice[tagName] = tagValue\n\t\tend\n\tend\n\n\treturn notice\nend\n",
+        "sendNotices": "function utils.notices.sendNotices(notices)\n\tfor _, notice in ipairs(notices) do\n\t\tao.send(notice)\n\tend\nend\n",
+        "notifyState": "function utils.notices.notifyState(msg, target)\n\tif not target then\n\t\tprint(\"No target specified for state notice\")\n\t\treturn\n\tend\n\tlocal state = {\n\t\tRecords = Records,\n\t\tControllers = Controllers,\n\t\tBalances = Balances,\n\t\tOwner = Owner,\n\t\tName = Name,\n\t\tTicker = Ticker,\n\t\tLogo = Logo,\n\t\tDenomination = Denomination,\n\t\tTotalSupply = TotalSupply,\n\t\tInitialized = Initialized,\n\t\t[\"Source-Code-TX-ID\"] = SourceCodeTxId,\n\t}\n\n\t-- Add forwarded tags to the records notice messages\n\tfor tagName, tagValue in pairs(msg) do\n\t\t-- Tags beginning with \"X-\" are forwarded\n\t\tif string.sub(tagName, 1, 2) == \"X-\" then\n\t\t\tstate[tagName] = tagValue\n\t\tend\n\tend\n\n\tao.send({ Target = target, Action = \"State-Notice\", Data = json.encode(state) })\nend\n"
+      },
+      "reduce": "\treturn function(...)\n\t\tlocal args = { ... }\n\n\t\tif #args >= arity then\n\t\t\treturn fn(table.unpack(args))\n\t\telse\n\t\t\treturn utils.curry(function(...)\n\t\t\t\treturn fn(table.unpack(args), ...)\n\t\t\tend, arity - #args)\n\t\tend\n\tend\n",
+      "find": "\treturn function(...)\n\t\tlocal args = { ... }\n\n\t\tif #args >= arity then\n\t\t\treturn fn(table.unpack(args))\n\t\telse\n\t\t\treturn utils.curry(function(...)\n\t\t\t\treturn fn(table.unpack(args), ...)\n\t\t\tend, arity - #args)\n\t\tend\n\tend\n",
+      "prop": "\treturn function(...)\n\t\tlocal args = { ... }\n\n\t\tif #args >= arity then\n\t\t\treturn fn(table.unpack(args))\n\t\telse\n\t\t\treturn utils.curry(function(...)\n\t\t\t\treturn fn(table.unpack(args), ...)\n\t\t\tend, arity - #args)\n\t\tend\n\tend\n",
+      "filter": "\treturn function(...)\n\t\tlocal args = { ... }\n\n\t\tif #args >= arity then\n\t\t\treturn fn(table.unpack(args))\n\t\telse\n\t\t\treturn utils.curry(function(...)\n\t\t\t\treturn fn(table.unpack(args), ...)\n\t\t\tend, arity - #args)\n\t\tend\n\tend\n",
+      "concat": "\treturn function(...)\n\t\tlocal args = { ... }\n\n\t\tif #args >= arity then\n\t\t\treturn fn(table.unpack(args))\n\t\telse\n\t\t\treturn utils.curry(function(...)\n\t\t\t\treturn fn(table.unpack(args), ...)\n\t\t\tend, arity - #args)\n\t\tend\n\tend\n",
+      "reply": "function utils.reply(msg)\n\tHandlers.utils.reply(msg)\nend\n",
+      "validateUndername": "function utils.validateUndername(name)\n\tlocal valid = string.match(name, constants.UNDERNAME_REGEXP) == nil\n\tassert(valid ~= false, constants.UNDERNAME_DOES_NOT_EXIST_MESSAGE)\nend\n",
+      "validateOwner": "function utils.validateOwner(caller)\n\tlocal isOwner = false\n\tif Owner == caller or Balances[caller] or ao.env.Process.Id == caller then\n\t\tisOwner = true\n\tend\n\tassert(isOwner, \"Sender is not the owner.\")\nend\n",
+      "curry": "utils.curry = function(fn, arity)\n\tassert(type(fn) == \"function\", \"function is required as first argument\")\n\tarity = arity or debug.getinfo(fn, \"u\").nparams\n\tif arity < 2 then\n\t\treturn fn\n\tend\n\n\treturn function(...)\n\t\tlocal args = { ... }\n\n\t\tif #args >= arity then\n\t\t\treturn fn(table.unpack(args))\n\t\telse\n\t\t\treturn utils.curry(function(...)\n\t\t\t\treturn fn(table.unpack(args), ...)\n\t\t\tend, arity - #args)\n\t\tend\n\tend\nend\n",
+      "validateTTLSeconds": "function utils.validateTTLSeconds(ttl)\n\tlocal valid = type(ttl) == \"number\" and ttl >= constants.MIN_TTL_SECONDS and ttl <= constants.MAX_TTL_SECONDS\n\treturn assert(valid ~= false, constants.INVALID_TTL_MESSAGE)\nend\n",
+      "keys": "utils.keys = function(t)\n\tassert(type(t) == \"table\", \"argument needs to be a table\")\n\tlocal keys = {}\n\tfor key in pairs(t) do\n\t\ttable.insert(keys, key)\n\tend\n\treturn keys\nend\n",
+      "assertHasPermission": "function utils.assertHasPermission(from)\n\tfor _, c in ipairs(Controllers) do\n\t\tif c == from then\n\t\t\t-- if is controller, return true\n\t\t\treturn\n\t\tend\n\tend\n\tif Owner == from then\n\t\treturn\n\tend\n\tif ao.env.Process.Id == from then\n\t\treturn\n\tend\n\tassert(false, \"Only controllers and owners can set controllers, records, and change metadata.\")\nend\n",
+      "includes": "\treturn function(...)\n\t\tlocal args = { ... }\n\n\t\tif #args >= arity then\n\t\t\treturn fn(table.unpack(args))\n\t\telse\n\t\t\treturn utils.curry(function(...)\n\t\t\t\treturn fn(table.unpack(args), ...)\n\t\t\tend, arity - #args)\n\t\tend\n\tend\n"
+    },
+    ".common.json": {
+      "_version": "0.1.2",
+      "encode": "function json.encode(val)\n\treturn (encode(val))\nend\n",
+      "decode": "function json.decode(str)\n\tif type(str) ~= \"string\" then\n\t\terror(\"expected argument of type string, got \" .. type(str))\n\tend\n\tlocal res, idx = parse(str, next_char(str, 1, space_chars, true))\n\tidx = next_char(str, idx, space_chars, true)\n\tif idx <= #str then\n\t\tdecode_error(str, idx, \"trailing garbage\")\n\tend\n\treturn res\nend\n"
+    },
+    ".crypto.cipher.aes192": {
+      "encrypt": ".crypto.cipher.aes192",
+      "blockSize": 16,
+      "decrypt": ".crypto.cipher.aes192"
+    }
+  },
+  "globals": {
+    "debug": "<circular reference>",
+    "Bell": "\u0007",
+    "Handlers": {
+      "coroutines": [],
+      "once": ".handlers",
+      "list": {
+        "1": {
+          "pattern": ".handlers-utils",
+          "name": "evolve",
+          "handle": ".handlers"
+        },
+        "2": {
+          "pattern": ".process",
+          "name": "_eval",
+          "handle": ".handlers"
+        },
+        "3": {
+          "pattern": {
+            "Action": "Program-State"
+          },
+          "name": "_programState",
+          "handle": ".handlers"
+        },
+        "4": {
+          "pattern": ".process",
+          "handle": ".handlers",
+          "name": "_boot",
+          "maxRuns": 1
+        },
+        "5": {
+          "pattern": ".process",
+          "name": "_default",
+          "handle": ".handlers"
+        },
+        "6": {
+          "pattern": ".handlers-utils",
+          "name": "transfer",
+          "handle": ".handlers"
+        },
+        "7": {
+          "pattern": ".handlers-utils",
+          "name": "balance",
+          "handle": ".handlers"
+        },
+        "8": {
+          "pattern": ".handlers-utils",
+          "name": "balances",
+          "handle": ".handlers"
+        },
+        "9": {
+          "pattern": ".handlers-utils",
+          "name": "totalSupply",
+          "handle": ".handlers"
+        },
+        "10": {
+          "pattern": ".handlers-utils",
+          "name": "info",
+          "handle": ".handlers"
+        },
+        "11": {
+          "pattern": ".handlers-utils",
+          "name": "addController",
+          "handle": ".handlers"
+        },
+        "12": {
+          "pattern": ".handlers-utils",
+          "name": "removeController",
+          "handle": ".handlers"
+        },
+        "13": {
+          "pattern": ".handlers-utils",
+          "name": "controllers",
+          "handle": ".handlers"
+        },
+        "14": {
+          "pattern": ".handlers-utils",
+          "name": "setRecord",
+          "handle": ".handlers"
+        },
+        "15": {
+          "pattern": ".handlers-utils",
+          "name": "removeRecord",
+          "handle": ".handlers"
+        },
+        "16": {
+          "pattern": ".handlers-utils",
+          "name": "record",
+          "handle": ".handlers"
+        },
+        "17": {
+          "pattern": ".handlers-utils",
+          "name": "records",
+          "handle": ".handlers"
+        },
+        "18": {
+          "pattern": ".handlers-utils",
+          "name": "setName",
+          "handle": ".handlers"
+        },
+        "19": {
+          "pattern": ".handlers-utils",
+          "name": "setTicker",
+          "handle": ".handlers"
+        },
+        "20": {
+          "pattern": ".handlers-utils",
+          "name": "initializeState",
+          "handle": ".handlers"
+        },
+        "21": {
+          "pattern": ".handlers-utils",
+          "name": "state",
+          "handle": ".handlers"
+        }
+      },
+      "before": ".handlers",
+      "onceNonce": 0,
+      "utils": {
+        "hasMatchingTag": ".handlers-utils",
+        "hasMatchingData": ".handlers-utils",
+        "_version": "0.0.2",
+        "hasMatchingTagOf": ".handlers-utils",
+        "reply": ".handlers-utils",
+        "continue": ".handlers-utils"
+      },
+      "receive": ".handlers",
+      "generateResolver": ".handlers",
+      "add": ".handlers",
+      "append": ".handlers",
+      "evaluate": ".handlers",
+      "_version": "0.0.5",
+      "after": ".handlers",
+      "remove": ".handlers",
+      "prepend": ".handlers"
+    },
+    "Tab": ".process",
+    "_G": "<circular reference>",
+    "Initialized": false,
+    "Controllers": {
+      "1": "FOOBAR"
+    },
+    "Prompt": ".process",
+    "tonumber": "",
+    "Errors": [],
+    "next": "",
+    "collectgarbage": "",
+    "Receive": ".process",
+    "assert": "",
+    "Assign": ".process",
+    "handle": "__lua_webassembly__",
+    "Spawn": ".process",
+    "Name": "Thomas",
+    "HANDLER_PRINT_LOGS": [],
+    "Colors": {
+      "gray": "\u001b[90m",
+      "blue": "\u001b[34m",
+      "green": "\u001b[32m",
+      "red": "\u001b[31m",
+      "reset": "\u001b[0m"
+    },
+    "Records": {
+      "@": {
+        "ttlSeconds": 3600,
+        "transactionId": "-k7t8xMoB8hW482609Z9F4bTFMC3MnuW8bTvTyT8pFI"
+      }
+    },
+    "rawget": "",
+    "Send": ".process",
+    "Inbox": [],
+    "xpcall": "",
+    "type": "",
+    "Denomination": 0,
+    "select": "",
+    "tostring": "",
+    "string": "<circular reference>",
+    "require": "",
+    "Version": ".process",
+    "io": {
+      "lines": "",
+      "flush": "",
+      "open": "",
+      "stderr": "<userdata>",
+      "write": "",
+      "read": "",
+      "input": "",
+      "type": "",
+      "close": "",
+      "popen": "",
+      "output": "",
+      "tmpfile": "",
+      "stdout": "<userdata>",
+      "stdin": "<userdata>"
+    },
+    "TotalSupply": 1,
+    "pairs": "",
+    "Balances": {
+      "FOOBAR": 1
+    },
+    "math": {
+      "deg": "",
+      "acos": "",
+      "log10": "",
+      "tan": "",
+      "ldexp": "",
+      "log": "",
+      "atan": "",
+      "sin": "",
+      "asin": "",
+      "abs": "",
+      "exp": "",
+      "ult": "",
+      "type": "",
+      "min": "",
+      "sqrt": "",
+      "sinh": "",
+      "tanh": "",
+      "cos": "",
+      "huge": "inf",
+      "random": ".process",
+      "atan2": "",
+      "cosh": "",
+      "max": "",
+      "frexp": "",
+      "tointeger": "",
+      "pi": 3.1415926535898,
+      "modf": "",
+      "fmod": "",
+      "rad": "",
+      "mininteger": -9223372036854800000,
+      "randomseed": "",
+      "floor": "",
+      "ceil": "",
+      "maxinteger": 9223372036854800000,
+      "pow": ""
+    },
+    "print": ".process",
+    "setmetatable": "",
+    "package": {
+      "searchers": {
+        "1": "",
+        "2": "main",
+        "3": "",
+        "4": "",
+        "5": ""
+      },
+      "path": "/usr/local/share/lua/5.3/?.lua;/usr/local/share/lua/5.3/?/init.lua;/usr/local/lib/lua/5.3/?.lua;/usr/local/lib/lua/5.3/?/init.lua;./?.lua;./?/init.lua",
+      "config": "/\n;\n?\n!\n-\n",
+      "searchpath": "",
+      "preload": [],
+      "loadlib": "",
+      "cpath": "/usr/local/lib/lua/5.3/?.so;/usr/local/lib/lua/5.3/loadall.so;./?.so",
+      "loaded": {
+        ".crypto.util.hex": {
+          "stringToHex": ".crypto.util.hex",
+          "hexToString": ".crypto.util.hex"
+        },
+        ".process": {
+          "_version": "2.0.0",
+          "handle": ".process"
+        },
+        ".common.records": {
+          "getRecords": "function records.getRecords()\n\treturn json.encode(Records)\nend\n",
+          "setRecord": "function records.setRecord(name, transactionId, ttlSeconds)\n\tlocal nameValidity, nameValidityError = pcall(utils.validateUndername, name)\n\tassert(nameValidity ~= false, nameValidityError)\n\tlocal targetIdValidity, targetValidityError = pcall(utils.validateArweaveId, transactionId)\n\tassert(targetIdValidity ~= false, targetValidityError)\n\tlocal ttlSecondsValidity, ttlValidityError = pcall(utils.validateTTLSeconds, ttlSeconds)\n\tassert(ttlSecondsValidity ~= false, ttlValidityError)\n\n\tlocal recordsCount = #Records\n\n\tif recordsCount >= 10000 then\n\t\terror(\"Max records limit of 10,000 reached, please delete some records to make space\")\n\tend\n\n\tRecords[name] = {\n\t\ttransactionId = transactionId,\n\t\tttlSeconds = ttlSeconds,\n\t}\n\n\treturn json.encode({\n\t\ttransactionId = transactionId,\n\t\tttlSeconds = ttlSeconds,\n\t})\nend\n",
+          "removeRecord": "function records.removeRecord(name)\n\tlocal nameValidity, nameValidityError = pcall(utils.validateUndername, name)\n\tassert(nameValidity ~= false, nameValidityError)\n\tRecords[name] = nil\n\treturn json.encode({ message = \"Record deleted\" })\nend\n",
+          "getRecord": "function records.getRecord(name)\n\tutils.validateUndername(name)\n\tassert(Records[name] ~= nil, \"Record does not exist\")\n\n\treturn json.encode(Records[name])\nend\n"
+        },
+        "debug": {
+          "setlocal": "",
+          "gethook": "",
+          "setuservalue": "",
+          "getlocal": "",
+          "debug": "",
+          "getregistry": "",
+          "getuservalue": "",
+          "getmetatable": "",
+          "upvaluejoin": "",
+          "getupvalue": "",
+          "getinfo": "",
+          "upvalueid": "",
+          "sethook": "",
+          "setmetatable": "",
+          "setupvalue": "",
+          "traceback": ""
+        },
+        ".crypto.cipher.morus": {
+          "decrypt": ".crypto.cipher.morus",
+          "variant": "Morus-1280",
+          "encrypt": ".crypto.cipher.morus",
+          "state_update": ".crypto.cipher.morus",
+          "key_size": 32,
+          "nonce_size": 16
+        },
+        ".common.main": {
+          "init": "function ant.init()\n\t-- main.lua\n\t-- utils\n\tlocal json = require(\".common.json\")\n\tlocal utils = require(\".common.utils\")\n\tlocal camel = utils.camelCase\n\t-- spec modules\n\tlocal balances = require(\".common.balances\")\n\tlocal initialize = require(\".common.initialize\")\n\tlocal records = require(\".common.records\")\n\tlocal controllers = require(\".common.controllers\")\n\n\tOwner = Owner or ao.env.Process.Owner\n\tBalances = Balances or { [Owner] = 1 }\n\tControllers = Controllers or { Owner }\n\n\tName = Name or \"Arweave Name Token\"\n\tTicker = Ticker or \"ANT\"\n\tLogo = Logo or \"Sie_26dvgyok0PZD_-iQAFOhOd5YxDTkczOLoqTTL_A\"\n\tDenomination = Denomination or 0\n\tTotalSupply = TotalSupply or 1\n\tInitialized = Initialized or false\n\t-- INSERT placeholder used by build script to inject the appropriate ID\n\tSourceCodeTxId = SourceCodeTxId or \"__INSERT_SOURCE_CODE_ID__\"\n\tAntRegistryId = AntRegistryId or ao.env.Process.Tags[\"ANT-Registry-Id\"] or nil\n\n\tlocal ActionMap = {\n\t\t-- write\n\t\tAddController = \"Add-Controller\",\n\t\tRemoveController = \"Remove-Controller\",\n\t\tSetRecord = \"Set-Record\",\n\t\tRemoveRecord = \"Remove-Record\",\n\t\tSetName = \"Set-Name\",\n\t\tSetTicker = \"Set-Ticker\",\n\t\t--- initialization method for bootstrapping the contract from other platforms ---\n\t\tInitializeState = \"Initialize-State\",\n\t\t-- read\n\t\tControllers = \"Controllers\",\n\t\tRecord = \"Record\",\n\t\tRecords = \"Records\",\n\t\tState = \"State\",\n\t\tEvolve = \"Evolve\",\n\t}\n\n\tlocal TokenSpecActionMap = {\n\t\tInfo = \"Info\",\n\t\tBalances = \"Balances\",\n\t\tBalance = \"Balance\",\n\t\tTransfer = \"Transfer\",\n\t\tTotalSupply = \"Total-Supply\",\n\t\tCreditNotice = \"Credit-Notice\",\n\t\t-- not implemented\n\t\tMint = \"Mint\",\n\t\tBurn = \"Burn\",\n\t}\n\n\tHandlers.add(\n\t\tcamel(TokenSpecActionMap.Transfer),\n\t\tutils.hasMatchingTag(\"Action\", TokenSpecActionMap.Transfer),\n\t\tfunction(msg)\n\t\t\tlocal recipient = msg.Tags.Recipient\n\t\t\tlocal function checkAssertions()\n\t\t\t\tutils.validateOwner(msg.From)\n\t\t\tend\n\n\t\t\tlocal inputStatus, inputResult = pcall(checkAssertions)\n\n\t\t\tif not inputStatus then\n\t\t\t\tao.send({\n\t\t\t\t\tTarget = msg.From,\n\t\t\t\t\tTags = { Action = \"Invalid-Transfer-Notice\", Error = \"Transfer-Error\" },\n\t\t\t\t\tData = tostring(inputResult),\n\t\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t\t})\n\t\t\t\treturn\n\t\t\tend\n\t\t\tlocal transferStatus, transferResult = pcall(balances.transfer, recipient)\n\n\t\t\tif not transferStatus then\n\t\t\t\tao.send({\n\t\t\t\t\tTarget = msg.From,\n\t\t\t\t\tTags = { Action = \"Invalid-Transfer-Notice\", Error = \"Transfer-Error\" },\n\t\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t\t\tData = tostring(transferResult),\n\t\t\t\t})\n\t\t\t\treturn\n\t\t\telseif not msg.Cast then\n\t\t\t\tao.send(utils.notices.debit(msg))\n\t\t\t\tao.send(utils.notices.credit(msg))\n\t\t\t\tutils.notices.notifyState(msg, AntRegistryId)\n\t\t\t\treturn\n\t\t\tend\n\t\t\tao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tData = transferResult,\n\t\t\t})\n\t\t\tutils.notices.notifyState(msg, AntRegistryId)\n\t\tend\n\t)\n\n\tHandlers.add(\n\t\tcamel(TokenSpecActionMap.Balance),\n\t\tutils.hasMatchingTag(\"Action\", TokenSpecActionMap.Balance),\n\t\tfunction(msg)\n\t\t\tlocal balStatus, balRes = pcall(balances.balance, msg.Tags.Recipient or msg.From)\n\t\t\tif not balStatus then\n\t\t\t\tao.send({\n\t\t\t\t\tTarget = msg.From,\n\t\t\t\t\tTags = { Action = \"Invalid-Balance-Notice\", Error = \"Balance-Error\" },\n\t\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t\t\tData = tostring(balRes),\n\t\t\t\t})\n\t\t\telse\n\t\t\t\tao.send({\n\t\t\t\t\tTarget = msg.From,\n\t\t\t\t\tAction = \"Balance-Notice\",\n\t\t\t\t\tBalance = tostring(balRes),\n\t\t\t\t\tTicker = Ticker,\n\t\t\t\t\tAddress = msg.Tags.Recipient or msg.From,\n\t\t\t\t\tData = balRes,\n\t\t\t\t})\n\t\t\tend\n\t\tend\n\t)\n\n\tHandlers.add(\n\t\tcamel(TokenSpecActionMap.Balances),\n\t\tutils.hasMatchingTag(\"Action\", TokenSpecActionMap.Balances),\n\t\tfunction(msg)\n\t\t\tao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tAction = \"Balances-Notice\",\n\t\t\t\tData = balances.balances(),\n\t\t\t})\n\t\tend\n\t)\n\n\tHandlers.add(\n\t\tcamel(TokenSpecActionMap.TotalSupply),\n\t\tutils.hasMatchingTag(\"Action\", TokenSpecActionMap.TotalSupply),\n\t\tfunction(msg)\n\t\t\tassert(msg.From ~= ao.id, \"Cannot call Total-Supply from the same process!\")\n\n\t\t\tao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tAction = \"Total-Supply-Notice\",\n\t\t\t\tData = TotalSupply,\n\t\t\t\tTicker = Ticker,\n\t\t\t})\n\t\tend\n\t)\n\n\tHandlers.add(camel(TokenSpecActionMap.Info), utils.hasMatchingTag(\"Action\", TokenSpecActionMap.Info), function(msg)\n\t\tlocal info = {\n\t\t\tName = Name,\n\t\t\tTicker = Ticker,\n\t\t\t[\"Total-Supply\"] = tostring(TotalSupply),\n\t\t\tLogo = Logo,\n\t\t\tDenomination = tostring(Denomination),\n\t\t\tOwner = Owner,\n\t\t\tHandlers = utils.getHandlerNames(Handlers),\n\t\t\t[\"Source-Code-TX-ID\"] = SourceCodeTxId,\n\t\t}\n\t\tao.send({\n\t\t\tTarget = msg.From,\n\t\t\tAction = \"Info-Notice\",\n\t\t\tTags = info,\n\t\t\tData = json.encode(info),\n\t\t})\n\tend)\n\n\t-- ActionMap (ANT Spec)\n\n\tHandlers.add(camel(ActionMap.AddController), utils.hasMatchingTag(\"Action\", ActionMap.AddController), function(msg)\n\t\tlocal assertHasPermission, permissionErr = pcall(utils.assertHasPermission, msg.From)\n\t\tif assertHasPermission == false then\n\t\t\treturn ao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tAction = \"Invalid-Add-Controller-Notice\",\n\t\t\t\tError = \"Add-Controller-Error\",\n\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t\tData = permissionErr,\n\t\t\t})\n\t\tend\n\t\tlocal controllerStatus, controllerRes = pcall(controllers.setController, msg.Tags.Controller)\n\t\tif not controllerStatus then\n\t\t\tao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tAction = \"Invalid-Add-Controller-Notice\",\n\t\t\t\tError = \"Add-Controller-Error\",\n\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t\tData = controllerRes,\n\t\t\t})\n\t\t\treturn\n\t\tend\n\t\tao.send({ Target = msg.From, Action = \"Add-Controller-Notice\", Data = controllerRes })\n\t\tutils.notices.notifyState(msg, AntRegistryId)\n\tend)\n\n\tHandlers.add(\n\t\tcamel(ActionMap.RemoveController),\n\t\tutils.hasMatchingTag(\"Action\", ActionMap.RemoveController),\n\t\tfunction(msg)\n\t\t\tlocal assertHasPermission, permissionErr = pcall(utils.assertHasPermission, msg.From)\n\t\t\tif assertHasPermission == false then\n\t\t\t\treturn ao.send({\n\t\t\t\t\tTarget = msg.From,\n\t\t\t\t\tAction = \"Invalid-Remove-Controller-Notice\",\n\t\t\t\t\tData = permissionErr,\n\t\t\t\t\tError = \"Remove-Controller-Error\",\n\t\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t\t})\n\t\t\tend\n\t\t\tlocal removeStatus, removeRes = pcall(controllers.removeController, msg.Tags.Controller)\n\t\t\tif not removeStatus then\n\t\t\t\tao.send({\n\t\t\t\t\tTarget = msg.From,\n\t\t\t\t\tAction = \"Invalid-Remove-Controller-Notice\",\n\t\t\t\t\tData = removeRes,\n\t\t\t\t\tError = \"Remove-Controller-Error\",\n\t\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t\t})\n\t\t\t\treturn\n\t\t\tend\n\n\t\t\tao.send({ Target = msg.From, Action = \"Remove-Controller-Notice\", Data = removeRes })\n\t\t\tutils.notices.notifyState(msg, AntRegistryId)\n\t\tend\n\t)\n\n\tHandlers.add(camel(ActionMap.Controllers), utils.hasMatchingTag(\"Action\", ActionMap.Controllers), function(msg)\n\t\tao.send({ Target = msg.From, Action = \"Controllers-Notice\", Data = controllers.getControllers() })\n\tend)\n\n\tHandlers.add(camel(ActionMap.SetRecord), utils.hasMatchingTag(\"Action\", ActionMap.SetRecord), function(msg)\n\t\tlocal assertHasPermission, permissionErr = pcall(utils.assertHasPermission, msg.From)\n\t\tif assertHasPermission == false then\n\t\t\treturn ao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tAction = \"Invalid-Set-Record-Notice\",\n\t\t\t\tData = permissionErr,\n\t\t\t\tError = \"Set-Record-Error\",\n\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t})\n\t\tend\n\t\tlocal tags = msg.Tags\n\t\tlocal name, transactionId, ttlSeconds =\n\t\t\tstring.lower(tags[\"Sub-Domain\"]), tags[\"Transaction-Id\"], tonumber(tags[\"TTL-Seconds\"])\n\n\t\tlocal setRecordStatus, setRecordResult = pcall(records.setRecord, name, transactionId, ttlSeconds)\n\t\tif not setRecordStatus then\n\t\t\tao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tAction = \"Invalid-Set-Record-Notice\",\n\t\t\t\tData = setRecordResult,\n\t\t\t\tError = \"Set-Record-Error\",\n\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t})\n\t\t\treturn\n\t\tend\n\n\t\tao.send({ Target = msg.From, Action = \"Set-Record-Notice\", Data = setRecordResult })\n\tend)\n\n\tHandlers.add(camel(ActionMap.RemoveRecord), utils.hasMatchingTag(\"Action\", ActionMap.RemoveRecord), function(msg)\n\t\tlocal assertHasPermission, permissionErr = pcall(utils.assertHasPermission, msg.From)\n\t\tif assertHasPermission == false then\n\t\t\treturn ao.send({ Target = msg.From, Action = \"Invalid-Remove-Record-Notice\", Data = permissionErr })\n\t\tend\n\t\tlocal name = string.lower(msg.Tags[\"Sub-Domain\"])\n\t\tlocal removeRecordStatus, removeRecordResult = pcall(records.removeRecord, name)\n\t\tif not removeRecordStatus then\n\t\t\tao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tAction = \"Invalid-Remove-Record-Notice\",\n\t\t\t\tData = removeRecordResult,\n\t\t\t\tError = \"Remove-Record-Error\",\n\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t})\n\t\telse\n\t\t\tao.send({ Target = msg.From, Data = removeRecordResult })\n\t\tend\n\tend)\n\n\tHandlers.add(camel(ActionMap.Record), utils.hasMatchingTag(\"Action\", ActionMap.Record), function(msg)\n\t\tlocal name = string.lower(msg.Tags[\"Sub-Domain\"])\n\t\tlocal nameStatus, nameRes = pcall(records.getRecord, name)\n\t\tif not nameStatus then\n\t\t\tao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tAction = \"Invalid-Record-Notice\",\n\t\t\t\tData = nameRes,\n\t\t\t\tError = \"Record-Error\",\n\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t})\n\t\t\treturn\n\t\tend\n\n\t\tlocal recordNotice = {\n\t\t\tTarget = msg.From,\n\t\t\tAction = \"Record-Notice\",\n\t\t\tName = name,\n\t\t\tData = nameRes,\n\t\t}\n\n\t\t-- Add forwarded tags to the credit and debit notice messages\n\t\tfor tagName, tagValue in pairs(msg) do\n\t\t\t-- Tags beginning with \"X-\" are forwarded\n\t\t\tif string.sub(tagName, 1, 2) == \"X-\" then\n\t\t\t\trecordNotice[tagName] = tagValue\n\t\t\tend\n\t\tend\n\n\t\t-- Send Record-Notice\n\t\tao.send(recordNotice)\n\tend)\n\n\tHandlers.add(camel(ActionMap.Records), utils.hasMatchingTag(\"Action\", ActionMap.Records), function(msg)\n\t\tlocal records = records.getRecords()\n\n\t\t-- Credit-Notice message template, that is sent to the Recipient of the transfer\n\t\tlocal recordsNotice = {\n\t\t\tTarget = msg.From,\n\t\t\tAction = \"Records-Notice\",\n\t\t\tData = records,\n\t\t}\n\n\t\t-- Add forwarded tags to the records notice messages\n\t\tfor tagName, tagValue in pairs(msg) do\n\t\t\t-- Tags beginning with \"X-\" are forwarded\n\t\t\tif string.sub(tagName, 1, 2) == \"X-\" then\n\t\t\t\trecordsNotice[tagName] = tagValue\n\t\t\tend\n\t\tend\n\n\t\t-- Send Records-Notice\n\t\tao.send(recordsNotice)\n\tend)\n\n\tHandlers.add(camel(ActionMap.SetName), utils.hasMatchingTag(\"Action\", ActionMap.SetName), function(msg)\n\t\tlocal assertHasPermission, permissionErr = pcall(utils.assertHasPermission, msg.From)\n\t\tif assertHasPermission == false then\n\t\t\treturn ao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tAction = \"Invalid-Set-Name-Notice\",\n\t\t\t\tData = permissionErr,\n\t\t\t\tError = \"Set-Name-Error\",\n\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t})\n\t\tend\n\t\tlocal nameStatus, nameRes = pcall(balances.setName, msg.Tags.Name)\n\t\tif not nameStatus then\n\t\t\tao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tAction = \"Invalid-Set-Name-Notice\",\n\t\t\t\tData = nameRes,\n\t\t\t\tError = \"Set-Name-Error\",\n\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t})\n\t\t\treturn\n\t\tend\n\t\tao.send({ Target = msg.From, Action = \"Set-Name-Notice\", Data = nameRes })\n\tend)\n\n\tHandlers.add(camel(ActionMap.SetTicker), utils.hasMatchingTag(\"Action\", ActionMap.SetTicker), function(msg)\n\t\tlocal assertHasPermission, permissionErr = pcall(utils.assertHasPermission, msg.From)\n\t\tif assertHasPermission == false then\n\t\t\treturn ao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tAction = \"Invalid-Set-Ticker-Notice\",\n\t\t\t\tData = permissionErr,\n\t\t\t\tError = \"Set-Ticker-Error\",\n\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t})\n\t\tend\n\t\tlocal tickerStatus, tickerRes = pcall(balances.setTicker, msg.Tags.Ticker)\n\t\tif not tickerStatus then\n\t\t\tao.send({\n\t\t\t\tTarget = msg.From,\n\t\t\t\tAction = \"Invalid-Set-Ticker-Notice\",\n\t\t\t\tData = tickerRes,\n\t\t\t\tError = \"Set-Ticker-Error\",\n\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t})\n\t\t\treturn\n\t\tend\n\n\t\tao.send({ Target = msg.From, Action = \"Set-Ticker-Notice\", Data = tickerRes })\n\tend)\n\n\tHandlers.add(\n\t\tcamel(ActionMap.InitializeState),\n\t\tutils.hasMatchingTag(\"Action\", ActionMap.InitializeState),\n\t\tfunction(msg)\n\t\t\tassert(msg.From == Owner, \"Only the owner can initialize the state\")\n\t\t\tlocal initStatus, result = pcall(initialize.initializeANTState, msg.Data)\n\n\t\t\tif not initStatus then\n\t\t\t\tao.send({\n\t\t\t\t\tTarget = msg.From,\n\t\t\t\t\tAction = \"Invalid-Initialize-State-Notice\",\n\t\t\t\t\tData = result,\n\t\t\t\t\tError = \"Initialize-State-Error\",\n\t\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t\t})\n\t\t\t\treturn\n\t\t\telse\n\t\t\t\tao.send({ Target = msg.From, Action = \"Initialize-State-Notice\", Data = result })\n\t\t\t\tutils.notices.notifyState(msg, AntRegistryId)\n\t\t\tend\n\t\tend\n\t)\n\tHandlers.add(camel(ActionMap.State), utils.hasMatchingTag(\"Action\", ActionMap.State), function(msg)\n\t\tutils.notices.notifyState(msg, msg.From)\n\tend)\n\n\tHandlers.prepend(\n\t\tcamel(ActionMap.Evolve),\n\t\tHandlers.utils.continue(utils.hasMatchingTag(\"Action\", \"Eval\")),\n\t\tfunction(msg)\n\t\t\tlocal srcCodeTxId = msg.Tags[\"Source-Code-TX-ID\"]\n\t\t\tif not srcCodeTxId then\n\t\t\t\treturn\n\t\t\tend\n\n\t\t\tif Owner ~= msg.From then\n\t\t\t\tao.send({\n\t\t\t\t\tTarget = msg.From,\n\t\t\t\t\tAction = \"Invalid-Evolve-Notice\",\n\t\t\t\t\tError = \"Evolve-Error\",\n\t\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t\t\tData = \"Only the Owner [\" .. Owner or \"no owner set\" .. \"] can call Evolve\",\n\t\t\t\t})\n\t\t\t\treturn\n\t\t\tend\n\n\t\t\tlocal srcCodeTxIdStatus, srcCodeTxIdResult = pcall(utils.validateArweaveId, srcCodeTxId)\n\t\t\tif srcCodeTxIdStatus and not srcCodeTxIdStatus then\n\t\t\t\tao.send({\n\t\t\t\t\tTarget = msg.From,\n\t\t\t\t\tAction = \"Invalid-Evolve-Notice\",\n\t\t\t\t\tError = \"Evolve-Error\",\n\t\t\t\t\t[\"Message-Id\"] = msg.Id,\n\t\t\t\t\tData = \"Source-Code-TX-ID is required\",\n\t\t\t\t})\n\t\t\t\treturn\n\t\t\tend\n\t\t\tSourceCodeTxId = srcCodeTxId\n\t\tend\n\t)\nend\n"
+        },
+        ".base64": {
+          "makedecoder": ".base64",
+          "decode": ".base64",
+          "encode": ".base64",
+          "makeencoder": ".base64"
+        },
+        ".handlers": "<circular reference>",
+        ".crypto.init": {
+          "utils": {
+            "bit": "<circular reference>",
+            "stream": {
+              "toString": ".crypto.util.stream",
+              "toHex": ".crypto.util.stream",
+              "toArray": ".crypto.util.stream",
+              "fromString": ".crypto.util.stream",
+              "fromHex": ".crypto.util.stream",
+              "fromArray": ".crypto.util.stream"
+            },
+            "_version": "0.0.1",
+            "array": {
+              "concat": ".crypto.util.array",
+              "readFromQueue": ".crypto.util.array",
+              "toStream": ".crypto.util.array",
+              "fromHex": ".crypto.util.array",
+              "toHex": ".crypto.util.array",
+              "slice": ".crypto.util.array",
+              "fromStream": ".crypto.util.array",
+              "toString": ".crypto.util.array",
+              "permute": ".crypto.util.array",
+              "writeToQueue": ".crypto.util.array",
+              "XOR": ".crypto.util.array",
+              "truncate": ".crypto.util.array",
+              "size": ".crypto.util.array",
+              "substitute": ".crypto.util.array",
+              "fromString": ".crypto.util.array",
+              "copy": ".crypto.util.array"
+            },
+            "hex": "<circular reference>",
+            "queue": ".crypto.util.queue"
+          },
+          "cipher": {
+            "norx": {
+              "variant": "NORX 64-4-1",
+              "nonce_size": 32,
+              "key_size": 32,
+              "decrypt": ".crypto.cipher.norx",
+              "encrypt": ".crypto.cipher.norx"
+            },
+            "issac": {
+              "random": ".crypto.cipher.issac",
+              "getRandomChar": ".crypto.cipher.issac",
+              "encrypt": ".crypto.cipher.issac",
+              "decrypt": ".crypto.cipher.issac",
+              "seedIsaac": ".crypto.cipher.issac",
+              "getRandom": ".crypto.cipher.issac"
+            },
+            "aes": {
+              "encrypt": ".crypto.cipher.aes",
+              "decrypt": ".crypto.cipher.aes"
+            },
+            "morus": "<circular reference>",
+            "_version": "0.0.1"
+          },
+          "random": ".crypto.cipher.issac",
+          "_version": "0.0.1",
+          "kdf": {
+            "_version": "0.0.1",
+            "pbkdf2": ".crypto.kdf.pbkdf2"
+          },
+          "digest": {
+            "sha2_512": ".crypto.digest.sha2_512",
+            "md5": ".crypto.digest.md5",
+            "md4": ".crypto.digest.md4",
+            "sha3_256": "",
+            "sha3_512": "",
+            "sha1": ".crypto.digest.sha1",
+            "keccak256": "",
+            "keccak512": "",
+            "_version": "0.0.1",
+            "md2": ".crypto.digest.md2",
+            "sha2_256": ".crypto.digest.sha2_256",
+            "blake2b": ".crypto.digest.blake2b"
+          },
+          "mac": {
+            "_version": "0.0.1",
+            "createHmac": ".crypto.mac.hmac"
+          }
+        },
+        ".common.initialize": {
+          "initializeANTState": "function initialize.initializeANTState(state)\n\tlocal encoded = json.decode(state)\n\tlocal balances = encoded.balances\n\tlocal controllers = encoded.controllers\n\tlocal records = encoded.records\n\tlocal name = encoded.name\n\tlocal ticker = encoded.ticker\n\tlocal owner = encoded.owner\n\tassert(type(name) == \"string\", \"name must be a string\")\n\tassert(type(ticker) == \"string\", \"ticker must be a string\")\n\tassert(type(balances) == \"table\", \"balances must be a table\")\n\tfor k, v in pairs(balances) do\n\t\tbalances[k] = tonumber(v)\n\tend\n\tassert(type(controllers) == \"table\", \"controllers must be a table\")\n\tassert(type(records) == \"table\", \"records must be a table\")\n\tassert(type(owner) == \"string\", \"owner must be a string\")\n\tfor k, v in pairs(records) do\n\t\tutils.validateUndername(k)\n\t\tassert(type(v) == \"table\", \"records values must be tables\")\n\t\tutils.validateArweaveId(v.transactionId)\n\t\tutils.validateTTLSeconds(v.ttlSeconds)\n\tend\n\n\tName = name\n\tTicker = ticker\n\tBalances = balances\n\tControllers = controllers\n\tRecords = records\n\tInitialized = true\n\tOwner = owner\n\n\treturn json.encode({\n\t\tname = Name,\n\t\tticker = Ticker,\n\t\tbalances = Balances,\n\t\tcontrollers = Controllers,\n\t\trecords = Records,\n\t\towner = Owner,\n\t\tinitialized = Initialized,\n\t})\nend\n",
+          "initializeProcessState": "function initialize.initializeProcessState(msg, env)\n\tErrors = Errors or {}\n\tInbox = Inbox or {}\n\n\t-- temporary fix for Spawn\n\tif not Owner then\n\t\tlocal _from = findObject(env.Process.Tags, \"name\", \"From-Process\")\n\t\tif _from then\n\t\t\tOwner = _from.value\n\t\telse\n\t\t\tOwner = msg.From\n\t\tend\n\tend\n\n\tif not Name then\n\t\tlocal taggedName = findObject(env.Process.Tags, \"name\", \"Name\")\n\t\tif taggedName then\n\t\t\tName = taggedName.value\n\t\telse\n\t\t\tName = \"ANT\"\n\t\tend\n\tend\nend\n"
+        },
+        ".crypto.digest.blake2b": ".crypto.digest.blake2b",
+        ".chance": {
+          "random": ".chance",
+          "seed": ".chance",
+          "integer": ".chance"
+        },
+        ".crypto.util.array": "<circular reference>",
+        ".common.balances": {
+          "setName": "function balances.setName(name)\n\tassert(type(name) == \"string\", \"Name must be a string\")\n\tName = name\n\treturn json.encode({ name = Name })\nend\n",
+          "balance": "function balances.balance(address)\n\tutils.validateArweaveId(address)\n\tlocal balance = Balances[address] or 0\n\treturn balance\nend\n",
+          "balances": "function balances.balances()\n\treturn json.encode(Balances)\nend\n",
+          "walletHasSufficientBalance": "function balances.walletHasSufficientBalance(wallet)\n\treturn Balances[wallet] ~= nil and Balances[wallet] > 0\nend\n",
+          "setTicker": "function balances.setTicker(ticker)\n\tassert(type(ticker) == \"string\", \"Ticker must be a string\")\n\tTicker = ticker\n\treturn json.encode({ ticker = Ticker })\nend\n",
+          "transfer": "function balances.transfer(to)\n\tutils.validateArweaveId(to)\n\tBalances = { [to] = 1 }\n\tOwner = to\n\tControllers = {}\n\treturn json.encode({ [to] = 1 })\nend\n"
+        },
+        ".common.controllers": {
+          "setController": "function controllers.setController(controller)\n\tutils.validateArweaveId(controller)\n\n\tfor _, c in ipairs(Controllers) do\n\t\tassert(c ~= controller, \"Controller already exists\")\n\tend\n\n\ttable.insert(Controllers, controller)\n\treturn json.encode(Controllers)\nend\n",
+          "getControllers": "function controllers.getControllers()\n\treturn json.encode(Controllers)\nend\n",
+          "removeController": "function controllers.removeController(controller)\n\tutils.validateArweaveId(controller)\n\tlocal controllerExists = false\n\n\tfor i, v in ipairs(Controllers) do\n\t\tif v == controller then\n\t\t\ttable.remove(Controllers, i)\n\t\t\tcontrollerExists = true\n\t\t\tbreak\n\t\tend\n\tend\n\n\tassert(controllerExists ~= nil, \"Controller does not exist\")\n\treturn json.encode(Controllers)\nend\n"
+        },
+        "ao": "<circular reference>",
+        ".crypto.digest.md2": ".crypto.digest.md2",
+        ".crypto.padding.zero": ".crypto.padding.zero",
+        ".crypto.kdf.init": "<circular reference>",
+        "json": {
+          "_version": "0.2.0",
+          "encode": "",
+          "decode": "json"
+        },
+        ".crypto.cipher.mode.ecb": {
+          "Cipher": ".crypto.cipher.mode.ecb",
+          "Decipher": ".crypto.cipher.mode.ecb"
+        },
+        "os": "<circular reference>",
+        ".crypto.cipher.mode.cbc": {
+          "Cipher": ".crypto.cipher.mode.cbc",
+          "Decipher": ".crypto.cipher.mode.cbc"
+        },
+        ".crypto.cipher.mode.ctr": {
+          "Cipher": ".crypto.cipher.mode.ctr",
+          "Decipher": ".crypto.cipher.mode.ctr"
+        },
+        ".crypto.digest.md4": ".crypto.digest.md4",
+        ".crypto.cipher.norx": "<circular reference>",
+        ".crypto.util.queue": ".crypto.util.queue",
+        ".crypto.mac.hmac": {
+          "hmac": ".crypto.mac.hmac",
+          "HMAC": ".crypto.mac.hmac"
+        },
+        "table": "<circular reference>",
+        "utf8": "<circular reference>",
+        ".stringify": {
+          "isSimpleArray": ".stringify",
+          "format": ".stringify",
+          "_version": "0.0.1"
+        },
+        ".crypto.cipher.mode.ofb": {
+          "Cipher": ".crypto.cipher.mode.ofb",
+          "Decipher": ".crypto.cipher.mode.ofb"
+        },
+        ".crypto.cipher.issac": "<circular reference>",
+        ".crypto.util.init": "<circular reference>",
+        ".crypto.cipher.mode.cfb": {
+          "Cipher": ".crypto.cipher.mode.cfb",
+          "Decipher": ".crypto.cipher.mode.cfb"
+        },
+        ".ao": "<circular reference>",
+        ".dump": ".dump",
+        ".crypto.cipher.init": "<circular reference>",
+        ".boot": ".boot",
+        ".utils": "<circular reference>",
+        ".crypto.digest.sha2_256": {
+          "sha2_256": ".crypto.digest.sha2_256",
+          "SHA2_256": ".crypto.digest.sha2_256"
+        },
+        "math": "<circular reference>",
+        ".crypto.digest.sha3": {
+          "sha3_512": "",
+          "keccak256": "",
+          "sha3_256": "",
+          "keccak512": ""
+        },
+        ".crypto.digest.sha2_512": ".crypto.digest.sha2_512",
+        ".pretty": {
+          "_version": "0.0.1",
+          "tprint": ".pretty"
+        },
+        ".default": ".default",
+        ".crypto.digest.md5": ".crypto.digest.md5",
+        "bit32": "<circular reference>",
+        "_G": "<circular reference>",
+        ".crypto.cipher.aes256": {
+          "encrypt": ".crypto.cipher.aes256",
+          "blockSize": 16,
+          "decrypt": ".crypto.cipher.aes256"
+        },
+        "coroutine": "<circular reference>",
+        "package": "<circular reference>",
+        ".crypto.util.bit": "<circular reference>",
+        ".common.constants": {
+          "MIN_TTL_SECONDS": 900,
+          "MAX_UNDERNAME_LENGTH": 61,
+          "UNDERNAME_DOES_NOT_EXIST_MESSAGE": "Name does not exist in the ANT!",
+          "UNDERNAME_REGEXP": "^(?:@|[a-zA-Z0-9][a-zA-Z0-9-_]{0,59}[a-zA-Z0-9])$",
+          "INVALID_ARWEAVE_ID_MESSAGE": "Invalid Arweave ID",
+          "MAX_TTL_SECONDS": 3600,
+          "ARWEAVE_ID_REGEXP": "^[a-zA-Z0-9-_]{43}$",
+          "INVALID_TTL_MESSAGE": "Invalid TTL. TLL must be an integer between 900 and 3600 seconds"
+        },
+        ".crypto.digest.sha1": {
+          "sha1": ".crypto.digest.sha1",
+          "SHA1": ".crypto.digest.sha1"
+        },
+        "io": "<circular reference>",
+        ".crypto.cipher.aes": "<circular reference>",
+        ".crypto.util.stream": "<circular reference>",
+        ".eval": ".eval",
+        "string": {
+          "byte": "",
+          "char": "",
+          "gmatch": "",
+          "packsize": "",
+          "lower": "",
+          "dump": "",
+          "reverse": "",
+          "unpack": "",
+          "find": "",
+          "rep": "",
+          "upper": "",
+          "match": "",
+          "sub": "",
+          "pack": "",
+          "format": "",
+          "len": "",
+          "gsub": ""
+        },
+        ".crypto.mac.init": "<circular reference>",
+        ".handlers-utils": "<circular reference>",
+        ".crypto.cipher.aes128": {
+          "encrypt": ".crypto.cipher.aes128",
+          "blockSize": 16,
+          "decrypt": ".crypto.cipher.aes128"
+        },
+        ".assignment": {
+          "_version": "0.1.0",
+          "init": ".assignment"
+        },
+        ".crypto.digest.init": "<circular reference>",
+        ".crypto.kdf.pbkdf2": {
+          "PBKDF2": ".crypto.kdf.pbkdf2",
+          "pbkdf2": ".crypto.kdf.pbkdf2"
+        },
+        ".common.utils": {
+          "getHandlerNames": "function utils.getHandlerNames(handlers)\n\tlocal names = {}\n\tfor _, handler in ipairs(handlers.list) do\n\t\ttable.insert(names, handler.name)\n\tend\n\treturn names\nend\n",
+          "values": "utils.values = function(t)\n\tassert(type(t) == \"table\", \"argument needs to be a table\")\n\tlocal values = {}\n\tfor _, value in pairs(t) do\n\t\ttable.insert(values, value)\n\tend\n\treturn values\nend\n",
+          "validateArweaveId": "function utils.validateArweaveId(id)\n\tlocal valid = string.match(id, constants.ARWEAVE_ID_REGEXP) == nil\n\n\tassert(valid == true, constants.INVALID_ARWEAVE_ID_MESSAGE)\nend\n",
+          "hasMatchingTag": "function utils.hasMatchingTag(tag, value)\n\treturn Handlers.utils.hasMatchingTag(tag, value)\nend\n",
+          "propEq": "\treturn function(...)\n\t\tlocal args = { ... }\n\n\t\tif #args >= arity then\n\t\t\treturn fn(table.unpack(args))\n\t\telse\n\t\t\treturn utils.curry(function(...)\n\t\t\t\treturn fn(table.unpack(args), ...)\n\t\t\tend, arity - #args)\n\t\tend\n\tend\n",
+          "_version": "0.0.1",
+          "map": "\treturn function(...)\n\t\tlocal args = { ... }\n\n\t\tif #args >= arity then\n\t\t\treturn fn(table.unpack(args))\n\t\telse\n\t\t\treturn utils.curry(function(...)\n\t\t\t\treturn fn(table.unpack(args), ...)\n\t\t\tend, arity - #args)\n\t\tend\n\tend\n",
+          "reverse": "utils.reverse = function(data)\n\tassert(type(data) == \"table\", \"argument needs to be a table that is an array\")\n\treturn utils.reduce(function(result, v, i)\n\t\tresult[#data - i + 1] = v\n\t\treturn result\n\tend, {}, data)\nend\n",
+          "compose": "\treturn function(...)\n\t\tlocal args = { ... }\n\n\t\tif #args >= arity then\n\t\t\treturn fn(table.unpack(args))\n\t\telse\n\t\t\treturn utils.curry(function(...)\n\t\t\t\treturn fn(table.unpack(args), ...)\n\t\t\tend, arity - #args)\n\t\tend\n\tend\n",
+          "camelCase": "function utils.camelCase(str)\n\t-- Remove any leading or trailing spaces\n\tstr = string.gsub(str, \"^%s*(.-)%s*$\", \"%1\")\n\n\t-- Convert PascalCase to camelCase\n\tstr = string.gsub(str, \"^%u\", string.lower)\n\n\t-- Handle kebab-case, snake_case, and space-separated words\n\tstr = string.gsub(str, \"[-_%s](%w)\", function(s)\n\t\treturn string.upper(s)\n\tend)\n\n\treturn str\nend\n",
+          "notices": {
+            "credit": "function utils.notices.credit(msg)\n\tlocal notice = {\n\t\tTarget = msg.Recipient,\n\t\tAction = \"Credit-Notice\",\n\t\tSender = msg.From,\n\t\tQuantity = tostring(1),\n\t}\n\tfor tagName, tagValue in pairs(msg) do\n\t\t-- Tags beginning with \"X-\" are forwarded\n\t\tif string.sub(tagName, 1, 2) == \"X-\" then\n\t\t\tnotice[tagName] = tagValue\n\t\tend\n\tend\n\n\treturn notice\nend\n",
+            "debit": "function utils.notices.debit(msg)\n\tlocal notice = {\n\t\tTarget = msg.From,\n\t\tAction = \"Debit-Notice\",\n\t\tRecipient = msg.Recipient,\n\t\tQuantity = tostring(1),\n\t}\n\t-- Add forwarded tags to the credit and debit notice messages\n\tfor tagName, tagValue in pairs(msg) do\n\t\t-- Tags beginning with \"X-\" are forwarded\n\t\tif string.sub(tagName, 1, 2) == \"X-\" then\n\t\t\tnotice[tagName] = tagValue\n\t\tend\n\tend\n\n\treturn notice\nend\n",
+            "sendNotices": "function utils.notices.sendNotices(notices)\n\tfor _, notice in ipairs(notices) do\n\t\tao.send(notice)\n\tend\nend\n",
+            "notifyState": "function utils.notices.notifyState(msg, target)\n\tif not target then\n\t\tprint(\"No target specified for state notice\")\n\t\treturn\n\tend\n\tlocal state = {\n\t\tRecords = Records,\n\t\tControllers = Controllers,\n\t\tBalances = Balances,\n\t\tOwner = Owner,\n\t\tName = Name,\n\t\tTicker = Ticker,\n\t\tLogo = Logo,\n\t\tDenomination = Denomination,\n\t\tTotalSupply = TotalSupply,\n\t\tInitialized = Initialized,\n\t\t[\"Source-Code-TX-ID\"] = SourceCodeTxId,\n\t}\n\n\t-- Add forwarded tags to the records notice messages\n\tfor tagName, tagValue in pairs(msg) do\n\t\t-- Tags beginning with \"X-\" are forwarded\n\t\tif string.sub(tagName, 1, 2) == \"X-\" then\n\t\t\tstate[tagName] = tagValue\n\t\tend\n\tend\n\n\tao.send({ Target = target, Action = \"State-Notice\", Data = json.encode(state) })\nend\n"
+          },
+          "reduce": "\treturn function(...)\n\t\tlocal args = { ... }\n\n\t\tif #args >= arity then\n\t\t\treturn fn(table.unpack(args))\n\t\telse\n\t\t\treturn utils.curry(function(...)\n\t\t\t\treturn fn(table.unpack(args), ...)\n\t\t\tend, arity - #args)\n\t\tend\n\tend\n",
+          "find": "\treturn function(...)\n\t\tlocal args = { ... }\n\n\t\tif #args >= arity then\n\t\t\treturn fn(table.unpack(args))\n\t\telse\n\t\t\treturn utils.curry(function(...)\n\t\t\t\treturn fn(table.unpack(args), ...)\n\t\t\tend, arity - #args)\n\t\tend\n\tend\n",
+          "prop": "\treturn function(...)\n\t\tlocal args = { ... }\n\n\t\tif #args >= arity then\n\t\t\treturn fn(table.unpack(args))\n\t\telse\n\t\t\treturn utils.curry(function(...)\n\t\t\t\treturn fn(table.unpack(args), ...)\n\t\t\tend, arity - #args)\n\t\tend\n\tend\n",
+          "filter": "\treturn function(...)\n\t\tlocal args = { ... }\n\n\t\tif #args >= arity then\n\t\t\treturn fn(table.unpack(args))\n\t\telse\n\t\t\treturn utils.curry(function(...)\n\t\t\t\treturn fn(table.unpack(args), ...)\n\t\t\tend, arity - #args)\n\t\tend\n\tend\n",
+          "concat": "\treturn function(...)\n\t\tlocal args = { ... }\n\n\t\tif #args >= arity then\n\t\t\treturn fn(table.unpack(args))\n\t\telse\n\t\t\treturn utils.curry(function(...)\n\t\t\t\treturn fn(table.unpack(args), ...)\n\t\t\tend, arity - #args)\n\t\tend\n\tend\n",
+          "reply": "function utils.reply(msg)\n\tHandlers.utils.reply(msg)\nend\n",
+          "validateUndername": "function utils.validateUndername(name)\n\tlocal valid = string.match(name, constants.UNDERNAME_REGEXP) == nil\n\tassert(valid ~= false, constants.UNDERNAME_DOES_NOT_EXIST_MESSAGE)\nend\n",
+          "validateOwner": "function utils.validateOwner(caller)\n\tlocal isOwner = false\n\tif Owner == caller or Balances[caller] or ao.env.Process.Id == caller then\n\t\tisOwner = true\n\tend\n\tassert(isOwner, \"Sender is not the owner.\")\nend\n",
+          "curry": "utils.curry = function(fn, arity)\n\tassert(type(fn) == \"function\", \"function is required as first argument\")\n\tarity = arity or debug.getinfo(fn, \"u\").nparams\n\tif arity < 2 then\n\t\treturn fn\n\tend\n\n\treturn function(...)\n\t\tlocal args = { ... }\n\n\t\tif #args >= arity then\n\t\t\treturn fn(table.unpack(args))\n\t\telse\n\t\t\treturn utils.curry(function(...)\n\t\t\t\treturn fn(table.unpack(args), ...)\n\t\t\tend, arity - #args)\n\t\tend\n\tend\nend\n",
+          "validateTTLSeconds": "function utils.validateTTLSeconds(ttl)\n\tlocal valid = type(ttl) == \"number\" and ttl >= constants.MIN_TTL_SECONDS and ttl <= constants.MAX_TTL_SECONDS\n\treturn assert(valid ~= false, constants.INVALID_TTL_MESSAGE)\nend\n",
+          "keys": "utils.keys = function(t)\n\tassert(type(t) == \"table\", \"argument needs to be a table\")\n\tlocal keys = {}\n\tfor key in pairs(t) do\n\t\ttable.insert(keys, key)\n\tend\n\treturn keys\nend\n",
+          "assertHasPermission": "function utils.assertHasPermission(from)\n\tfor _, c in ipairs(Controllers) do\n\t\tif c == from then\n\t\t\t-- if is controller, return true\n\t\t\treturn\n\t\tend\n\tend\n\tif Owner == from then\n\t\treturn\n\tend\n\tif ao.env.Process.Id == from then\n\t\treturn\n\tend\n\tassert(false, \"Only controllers and owners can set controllers, records, and change metadata.\")\nend\n",
+          "includes": "\treturn function(...)\n\t\tlocal args = { ... }\n\n\t\tif #args >= arity then\n\t\t\treturn fn(table.unpack(args))\n\t\telse\n\t\t\treturn utils.curry(function(...)\n\t\t\t\treturn fn(table.unpack(args), ...)\n\t\t\tend, arity - #args)\n\t\tend\n\tend\n"
+        },
+        ".common.json": {
+          "_version": "0.1.2",
+          "encode": "function json.encode(val)\n\treturn (encode(val))\nend\n",
+          "decode": "function json.decode(str)\n\tif type(str) ~= \"string\" then\n\t\terror(\"expected argument of type string, got \" .. type(str))\n\tend\n\tlocal res, idx = parse(str, next_char(str, 1, space_chars, true))\n\tidx = next_char(str, idx, space_chars, true)\n\tif idx <= #str then\n\t\tdecode_error(str, idx, \"trailing garbage\")\n\tend\n\treturn res\nend\n"
+        },
+        ".crypto.cipher.aes192": {
+          "encrypt": ".crypto.cipher.aes192",
+          "blockSize": 16,
+          "decrypt": ".crypto.cipher.aes192"
+        }
+      }
+    },
+    "ao": {
+      "removeAssignable": ".assignment",
+      "isAssignable": ".assignment",
+      "reference": 0,
+      "outbox": {
+        "Messages": [],
+        "Spawns": [],
+        "Output": [],
+        "Assignments": []
+      },
+      "sanitize": ".ao",
+      "send": ".process",
+      "result": ".ao",
+      "_version": "0.0.6",
+      "init": ".ao",
+      "spawn": ".process",
+      "authorities": {
+        "1": "BOOP"
+      },
+      "id": "AOS",
+      "normalize": ".ao",
+      "nonExtractableTags": {
+        "1": "Data-Protocol",
+        "2": "Variant",
+        "3": "From-Process",
+        "4": "From-Module",
+        "5": "Type",
+        "6": "From",
+        "7": "Owner",
+        "8": "Anchor",
+        "9": "Target",
+        "10": "Data",
+        "11": "Tags"
+      },
+      "log": ".ao",
+      "isAssignment": "",
+      "assignables": [],
+      "env": {
+        "Process": {
+          "Owner": "FOOBAR",
+          "Id": "AOS",
+          "TagArray": {
+            "1": {
+              "name": "Name",
+              "value": "Thomas"
+            },
+            "2": {
+              "name": "Authority",
+              "value": "BOOP"
+            }
+          },
+          "Tags": {
+            "Name": "Thomas",
+            "Authority": "BOOP"
+          }
+        }
+      },
+      "nonForwardableTags": {
+        "1": "Data-Protocol",
+        "2": "Variant",
+        "3": "From-Process",
+        "4": "From-Module",
+        "5": "Type",
+        "6": "From",
+        "7": "Owner",
+        "8": "Anchor",
+        "9": "Target",
+        "10": "Tags",
+        "11": "TagArray",
+        "12": "Hash-Chain",
+        "13": "Timestamp",
+        "14": "Nonce",
+        "15": "Epoch",
+        "16": "Signature",
+        "17": "Forwarded-By",
+        "18": "Pushed-For",
+        "19": "Read-Only",
+        "20": "Cron",
+        "21": "Block-Height",
+        "22": "Reference",
+        "23": "Id",
+        "24": "Reply-To"
+      },
+      "_module": "",
+      "clearOutbox": ".ao",
+      "assign": ".ao",
+      "addAssignable": ".assignment",
+      "clone": ".ao",
+      "isTrusted": ".ao"
+    },
+    "load": "",
+    "getmetatable": "",
+    "loadfile": "",
+    "bit32": {
+      "arshift": "",
+      "bnot": "",
+      "bxor": "",
+      "bor": "",
+      "btest": "",
+      "lshift": "",
+      "lrotate": "",
+      "extract": "",
+      "band": "",
+      "rrotate": "",
+      "replace": "",
+      "rshift": ""
+    },
+    "coroutine": {
+      "wrap": "",
+      "create": "",
+      "running": "",
+      "resume": "",
+      "status": "",
+      "yield": "",
+      "isyieldable": ""
+    },
+    "dofile": "",
+    "rawlen": "",
+    "ipairs": "",
+    "SourceCodeTxId": "__INSERT_SOURCE_CODE_ID__",
+    "pcall": "",
+    "Owner": "FOOBAR",
+    "Logo": "Sie_26dvgyok0PZD_-iQAFOhOd5YxDTkczOLoqTTL_A",
+    "Dump": ".dump",
+    "Ticker": "ANT",
+    "rawequal": "",
+    "utf8": {
+      "charpattern": "[\u0000-�-�][�-�]*",
+      "codepoint": "",
+      "char": "",
+      "offset": "",
+      "len": "",
+      "codes": ""
+    },
+    "table": {
+      "unpack": "",
+      "insert": "",
+      "pack": "",
+      "remove": "",
+      "sort": "",
+      "move": "",
+      "concat": ""
+    },
+    "_VERSION": "Lua 5.3",
+    "os": {
+      "tmpname": "",
+      "setlocale": "",
+      "getenv": "",
+      "time": ".process",
+      "rename": "",
+      "execute": "",
+      "difftime": "",
+      "exit": "",
+      "date": "",
+      "remove": "",
+      "clock": ""
+    },
+    "Seeded": true,
+    "Utils": {
+      "values": ".utils",
+      "propEq": ".utils",
+      "parseValue": ".utils",
+      "map": ".utils",
+      "reverse": ".utils",
+      "reduce": ".utils",
+      "keys": ".utils",
+      "_version": "0.0.5",
+      "find": ".utils",
+      "getProgramState": ".utils",
+      "filter": ".utils",
+      "matchesPattern": ".utils",
+      "prop": ".utils",
+      "compose": ".utils",
+      "concat": ".utils",
+      "parseCoroutine": ".utils",
+      "parseFunctionCode": ".utils",
+      "curry": ".utils",
+      "matchesSpec": ".utils",
+      "includes": ".utils"
+    },
+    "rawset": "",
+    "error": ""
+  }
+}

--- a/process/aos-bundled.lua
+++ b/process/aos-bundled.lua
@@ -1,0 +1,1451 @@
+
+
+-- module: ".common.json"
+local function _loaded_mod_common_json()
+--
+-- json.lua
+--
+-- Copyright (c) 2020 rxi
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy of
+-- this software and associated documentation files (the "Software"), to deal in
+-- the Software without restriction, including without limitation the rights to
+-- use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+-- of the Software, and to permit persons to whom the Software is furnished to do
+-- so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in all
+-- copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+--
+
+local json = { _version = "0.1.2" }
+
+-------------------------------------------------------------------------------
+-- Encode
+-------------------------------------------------------------------------------
+
+local encode
+
+local escape_char_map = {
+	["\\"] = "\\",
+	['"'] = '"',
+	["\b"] = "b",
+	["\f"] = "f",
+	["\n"] = "n",
+	["\r"] = "r",
+	["\t"] = "t",
+}
+
+local escape_char_map_inv = { ["/"] = "/" }
+for k, v in pairs(escape_char_map) do
+	escape_char_map_inv[v] = k
+end
+
+local function escape_char(c)
+	return "\\" .. (escape_char_map[c] or string.format("u%04x", c:byte()))
+end
+
+local function encode_nil(val)
+	return "null"
+end
+
+local function encode_table(val, stack)
+	local res = {}
+	stack = stack or {}
+
+	-- Circular reference?
+	if stack[val] then
+		error("circular reference")
+	end
+
+	stack[val] = true
+
+	if rawget(val, 1) ~= nil or next(val) == nil then
+		-- Treat as array -- check keys are valid and it is not sparse
+		local n = 0
+		for k in pairs(val) do
+			if type(k) ~= "number" then
+				error("invalid table: mixed or invalid key types")
+			end
+			n = n + 1
+		end
+		if n ~= #val then
+			error("invalid table: sparse array")
+		end
+		-- Encode
+		for i, v in ipairs(val) do
+			table.insert(res, encode(v, stack))
+		end
+		stack[val] = nil
+		return "[" .. table.concat(res, ",") .. "]"
+	else
+		-- Treat as an object
+		for k, v in pairs(val) do
+			if type(k) ~= "string" then
+				error("invalid table: mixed or invalid key types")
+			end
+			table.insert(res, encode(k, stack) .. ":" .. encode(v, stack))
+		end
+		stack[val] = nil
+		return "{" .. table.concat(res, ",") .. "}"
+	end
+end
+
+local function encode_string(val)
+	return '"' .. val:gsub('[%z\1-\31\\"]', escape_char) .. '"'
+end
+
+local function encode_number(val)
+	-- Check for NaN, -inf and inf
+	if val ~= val or val <= -math.huge or val >= math.huge then
+		error("unexpected number value '" .. tostring(val) .. "'")
+	end
+	return string.format("%.14g", val)
+end
+
+local type_func_map = {
+	["nil"] = encode_nil,
+	["table"] = encode_table,
+	["string"] = encode_string,
+	["number"] = encode_number,
+	["boolean"] = tostring,
+}
+
+encode = function(val, stack)
+	local t = type(val)
+	local f = type_func_map[t]
+	if f then
+		return f(val, stack)
+	end
+	error("unexpected type '" .. t .. "'")
+end
+
+function json.encode(val)
+	return (encode(val))
+end
+
+-------------------------------------------------------------------------------
+-- Decode
+-------------------------------------------------------------------------------
+
+local parse
+
+local function create_set(...)
+	local res = {}
+	for i = 1, select("#", ...) do
+		res[select(i, ...)] = true
+	end
+	return res
+end
+
+local space_chars = create_set(" ", "\t", "\r", "\n")
+local delim_chars = create_set(" ", "\t", "\r", "\n", "]", "}", ",")
+local escape_chars = create_set("\\", "/", '"', "b", "f", "n", "r", "t", "u")
+local literals = create_set("true", "false", "null")
+
+local literal_map = {
+	["true"] = true,
+	["false"] = false,
+	["null"] = nil,
+}
+
+local function next_char(str, idx, set, negate)
+	for i = idx, #str do
+		if set[str:sub(i, i)] ~= negate then
+			return i
+		end
+	end
+	return #str + 1
+end
+
+local function decode_error(str, idx, msg)
+	local line_count = 1
+	local col_count = 1
+	for i = 1, idx - 1 do
+		col_count = col_count + 1
+		if str:sub(i, i) == "\n" then
+			line_count = line_count + 1
+			col_count = 1
+		end
+	end
+	error(string.format("%s at line %d col %d", msg, line_count, col_count))
+end
+
+local function codepoint_to_utf8(n)
+	-- http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=iws-appendixa
+	local f = math.floor
+	if n <= 0x7f then
+		return string.char(n)
+	elseif n <= 0x7ff then
+		return string.char(f(n / 64) + 192, n % 64 + 128)
+	elseif n <= 0xffff then
+		return string.char(f(n / 4096) + 224, f(n % 4096 / 64) + 128, n % 64 + 128)
+	elseif n <= 0x10ffff then
+		return string.char(f(n / 262144) + 240, f(n % 262144 / 4096) + 128, f(n % 4096 / 64) + 128, n % 64 + 128)
+	end
+	error(string.format("invalid unicode codepoint '%x'", n))
+end
+
+local function parse_unicode_escape(s)
+	local n1 = tonumber(s:sub(1, 4), 16)
+	local n2 = tonumber(s:sub(7, 10), 16)
+	-- Surrogate pair?
+	if n2 then
+		return codepoint_to_utf8((n1 - 0xd800) * 0x400 + (n2 - 0xdc00) + 0x10000)
+	else
+		return codepoint_to_utf8(n1)
+	end
+end
+
+local function parse_string(str, i)
+	local res = ""
+	local j = i + 1
+	local k = j
+
+	while j <= #str do
+		local x = str:byte(j)
+
+		if x < 32 then
+			decode_error(str, j, "control character in string")
+		elseif x == 92 then -- `\`: Escape
+			res = res .. str:sub(k, j - 1)
+			j = j + 1
+			local c = str:sub(j, j)
+			if c == "u" then
+				local hex = str:match("^[dD][89aAbB]%x%x\\u%x%x%x%x", j + 1)
+					or str:match("^%x%x%x%x", j + 1)
+					or decode_error(str, j - 1, "invalid unicode escape in string")
+				res = res .. parse_unicode_escape(hex)
+				j = j + #hex
+			else
+				if not escape_chars[c] then
+					decode_error(str, j - 1, "invalid escape char '" .. c .. "' in string")
+				end
+				res = res .. escape_char_map_inv[c]
+			end
+			k = j + 1
+		elseif x == 34 then -- `"`: End of string
+			res = res .. str:sub(k, j - 1)
+			return res, j + 1
+		end
+
+		j = j + 1
+	end
+
+	decode_error(str, i, "expected closing quote for string")
+end
+
+local function parse_number(str, i)
+	local x = next_char(str, i, delim_chars)
+	local s = str:sub(i, x - 1)
+	local n = tonumber(s)
+	if not n then
+		decode_error(str, i, "invalid number '" .. s .. "'")
+	end
+	return n, x
+end
+
+local function parse_literal(str, i)
+	local x = next_char(str, i, delim_chars)
+	local word = str:sub(i, x - 1)
+	if not literals[word] then
+		decode_error(str, i, "invalid literal '" .. word .. "'")
+	end
+	return literal_map[word], x
+end
+
+local function parse_array(str, i)
+	local res = {}
+	local n = 1
+	i = i + 1
+	while 1 do
+		local x
+		i = next_char(str, i, space_chars, true)
+		-- Empty / end of array?
+		if str:sub(i, i) == "]" then
+			i = i + 1
+			break
+		end
+		-- Read token
+		x, i = parse(str, i)
+		res[n] = x
+		n = n + 1
+		-- Next token
+		i = next_char(str, i, space_chars, true)
+		local chr = str:sub(i, i)
+		i = i + 1
+		if chr == "]" then
+			break
+		end
+		if chr ~= "," then
+			decode_error(str, i, "expected ']' or ','")
+		end
+	end
+	return res, i
+end
+
+local function parse_object(str, i)
+	local res = {}
+	i = i + 1
+	while 1 do
+		local key, val
+		i = next_char(str, i, space_chars, true)
+		-- Empty / end of object?
+		if str:sub(i, i) == "}" then
+			i = i + 1
+			break
+		end
+		-- Read key
+		if str:sub(i, i) ~= '"' then
+			decode_error(str, i, "expected string for key")
+		end
+		key, i = parse(str, i)
+		-- Read ':' delimiter
+		i = next_char(str, i, space_chars, true)
+		if str:sub(i, i) ~= ":" then
+			decode_error(str, i, "expected ':' after key")
+		end
+		i = next_char(str, i + 1, space_chars, true)
+		-- Read value
+		val, i = parse(str, i)
+		-- Set
+		res[key] = val
+		-- Next token
+		i = next_char(str, i, space_chars, true)
+		local chr = str:sub(i, i)
+		i = i + 1
+		if chr == "}" then
+			break
+		end
+		if chr ~= "," then
+			decode_error(str, i, "expected '}' or ','")
+		end
+	end
+	return res, i
+end
+
+local char_func_map = {
+	['"'] = parse_string,
+	["0"] = parse_number,
+	["1"] = parse_number,
+	["2"] = parse_number,
+	["3"] = parse_number,
+	["4"] = parse_number,
+	["5"] = parse_number,
+	["6"] = parse_number,
+	["7"] = parse_number,
+	["8"] = parse_number,
+	["9"] = parse_number,
+	["-"] = parse_number,
+	["t"] = parse_literal,
+	["f"] = parse_literal,
+	["n"] = parse_literal,
+	["["] = parse_array,
+	["{"] = parse_object,
+}
+
+parse = function(str, idx)
+	local chr = str:sub(idx, idx)
+	local f = char_func_map[chr]
+	if f then
+		return f(str, idx)
+	end
+	decode_error(str, idx, "unexpected character '" .. chr .. "'")
+end
+
+function json.decode(str)
+	if type(str) ~= "string" then
+		error("expected argument of type string, got " .. type(str))
+	end
+	local res, idx = parse(str, next_char(str, 1, space_chars, true))
+	idx = next_char(str, idx, space_chars, true)
+	if idx <= #str then
+		decode_error(str, idx, "trailing garbage")
+	end
+	return res
+end
+
+return json
+
+end
+
+_G.package.loaded[".common.json"] = _loaded_mod_common_json()
+
+-- module: ".common.constants"
+local function _loaded_mod_common_constants()
+local constants = {}
+
+constants.MAX_UNDERNAME_LENGTH = 61
+constants.UNDERNAME_DOES_NOT_EXIST_MESSAGE = "Name does not exist in the ANT!"
+constants.UNDERNAME_REGEXP = "^(?:@|[a-zA-Z0-9][a-zA-Z0-9-_]{0,"
+	.. (constants.MAX_UNDERNAME_LENGTH - 2)
+	.. "}[a-zA-Z0-9])$"
+constants.ARWEAVE_ID_REGEXP = "^[a-zA-Z0-9-_]{43}$"
+constants.INVALID_ARWEAVE_ID_MESSAGE = "Invalid Arweave ID"
+constants.MIN_TTL_SECONDS = 900
+constants.MAX_TTL_SECONDS = 3600
+constants.INVALID_TTL_MESSAGE = "Invalid TTL. TLL must be an integer between "
+	.. constants.MIN_TTL_SECONDS
+	.. " and "
+	.. constants.MAX_TTL_SECONDS
+	.. " seconds"
+
+return constants
+
+end
+
+_G.package.loaded[".common.constants"] = _loaded_mod_common_constants()
+
+-- module: ".common.utils"
+local function _loaded_mod_common_utils()
+-- the majority of this file came from https://github.com/permaweb/aos/blob/main/process/utils.lua
+
+local constants = require(".common.constants")
+local json = require("json")
+local utils = { _version = "0.0.1" }
+
+local function isArray(table)
+	if type(table) == "table" then
+		local maxIndex = 0
+		for k, v in pairs(table) do
+			if type(k) ~= "number" or k < 1 or math.floor(k) ~= k then
+				return false -- If there's a non-integer key, it's not an array
+			end
+			maxIndex = math.max(maxIndex, k)
+		end
+		-- If the highest numeric index is equal to the number of elements, it's an array
+		return maxIndex == #table
+	end
+	return false
+end
+
+-- @param {function} fn
+-- @param {number} arity
+utils.curry = function(fn, arity)
+	assert(type(fn) == "function", "function is required as first argument")
+	arity = arity or debug.getinfo(fn, "u").nparams
+	if arity < 2 then
+		return fn
+	end
+
+	return function(...)
+		local args = { ... }
+
+		if #args >= arity then
+			return fn(table.unpack(args))
+		else
+			return utils.curry(function(...)
+				return fn(table.unpack(args), ...)
+			end, arity - #args)
+		end
+	end
+end
+
+--- Concat two Array Tables.
+-- @param {table<Array>} a
+-- @param {table<Array>} b
+utils.concat = utils.curry(function(a, b)
+	assert(type(a) == "table", "first argument should be a table that is an array")
+	assert(type(b) == "table", "second argument should be a table that is an array")
+	assert(isArray(a), "first argument should be a table")
+	assert(isArray(b), "second argument should be a table")
+
+	local result = {}
+	for i = 1, #a do
+		result[#result + 1] = a[i]
+	end
+	for i = 1, #b do
+		result[#result + 1] = b[i]
+	end
+	return result
+end, 2)
+
+--- reduce applies a function to a table
+-- @param {function} fn
+-- @param {any} initial
+-- @param {table<Array>} t
+utils.reduce = utils.curry(function(fn, initial, t)
+	assert(type(fn) == "function", "first argument should be a function that accepts (result, value, key)")
+	assert(type(t) == "table" and isArray(t), "third argument should be a table that is an array")
+	local result = initial
+	for k, v in pairs(t) do
+		if result == nil then
+			result = v
+		else
+			result = fn(result, v, k)
+		end
+	end
+	return result
+end, 3)
+
+-- @param {function} fn
+-- @param {table<Array>} data
+utils.map = utils.curry(function(fn, data)
+	assert(type(fn) == "function", "first argument should be a unary function")
+	assert(type(data) == "table" and isArray(data), "second argument should be an Array")
+
+	local function map(result, v, k)
+		result[k] = fn(v, k)
+		return result
+	end
+
+	return utils.reduce(map, {}, data)
+end, 2)
+
+-- @param {function} fn
+-- @param {table<Array>} data
+utils.filter = utils.curry(function(fn, data)
+	assert(type(fn) == "function", "first argument should be a unary function")
+	assert(type(data) == "table" and isArray(data), "second argument should be an Array")
+
+	local function filter(result, v, _k)
+		if fn(v) then
+			table.insert(result, v)
+		end
+		return result
+	end
+
+	return utils.reduce(filter, {}, data)
+end, 2)
+
+-- @param {function} fn
+-- @param {table<Array>} t
+utils.find = utils.curry(function(fn, t)
+	assert(type(fn) == "function", "first argument should be a unary function")
+	assert(type(t) == "table", "second argument should be a table that is an array")
+	for _, v in pairs(t) do
+		if fn(v) then
+			return v
+		end
+	end
+end, 2)
+
+-- @param {string} propName
+-- @param {string} value
+-- @param {table} object
+utils.propEq = utils.curry(function(propName, value, object)
+	assert(type(propName) == "string", "first argument should be a string")
+	-- assert(type(value) == "string", "second argument should be a string")
+	assert(type(object) == "table", "third argument should be a table<object>")
+
+	return object[propName] == value
+end, 3)
+
+-- @param {table<Array>} data
+utils.reverse = function(data)
+	assert(type(data) == "table", "argument needs to be a table that is an array")
+	return utils.reduce(function(result, v, i)
+		result[#data - i + 1] = v
+		return result
+	end, {}, data)
+end
+
+-- @param {function} ...
+utils.compose = utils.curry(function(...)
+	local mutations = utils.reverse({ ... })
+
+	return function(v)
+		local result = v
+		for _, fn in pairs(mutations) do
+			assert(type(fn) == "function", "each argument needs to be a function")
+			result = fn(result)
+		end
+		return result
+	end
+end, 2)
+
+-- @param {string} propName
+-- @param {table} object
+utils.prop = utils.curry(function(propName, object)
+	return object[propName]
+end, 2)
+
+-- @param {any} val
+-- @param {table<Array>} t
+utils.includes = utils.curry(function(val, t)
+	assert(type(t) == "table", "argument needs to be a table")
+	return utils.find(function(v)
+		return v == val
+	end, t) ~= nil
+end, 2)
+
+-- @param {table} t
+utils.keys = function(t)
+	assert(type(t) == "table", "argument needs to be a table")
+	local keys = {}
+	for key in pairs(t) do
+		table.insert(keys, key)
+	end
+	return keys
+end
+
+-- @param {table} t
+utils.values = function(t)
+	assert(type(t) == "table", "argument needs to be a table")
+	local values = {}
+	for _, value in pairs(t) do
+		table.insert(values, value)
+	end
+	return values
+end
+
+function utils.hasMatchingTag(tag, value)
+	return Handlers.utils.hasMatchingTag(tag, value)
+end
+
+function utils.reply(msg)
+	Handlers.utils.reply(msg)
+end
+
+function utils.validateUndername(name)
+	local valid = string.match(name, constants.UNDERNAME_REGEXP) == nil
+	assert(valid ~= false, constants.UNDERNAME_DOES_NOT_EXIST_MESSAGE)
+end
+
+function utils.validateArweaveId(id)
+	local valid = string.match(id, constants.ARWEAVE_ID_REGEXP) == nil
+
+	assert(valid == true, constants.INVALID_ARWEAVE_ID_MESSAGE)
+end
+
+function utils.validateTTLSeconds(ttl)
+	local valid = type(ttl) == "number" and ttl >= constants.MIN_TTL_SECONDS and ttl <= constants.MAX_TTL_SECONDS
+	return assert(valid ~= false, constants.INVALID_TTL_MESSAGE)
+end
+
+function utils.validateOwner(caller)
+	local isOwner = false
+	if Owner == caller or Balances[caller] or ao.env.Process.Id == caller then
+		isOwner = true
+	end
+	assert(isOwner, "Sender is not the owner.")
+end
+
+function utils.assertHasPermission(from)
+	for _, c in ipairs(Controllers) do
+		if c == from then
+			-- if is controller, return true
+			return
+		end
+	end
+	if Owner == from then
+		return
+	end
+	if ao.env.Process.Id == from then
+		return
+	end
+	assert(false, "Only controllers and owners can set controllers, records, and change metadata.")
+end
+
+function utils.camelCase(str)
+	-- Remove any leading or trailing spaces
+	str = string.gsub(str, "^%s*(.-)%s*$", "%1")
+
+	-- Convert PascalCase to camelCase
+	str = string.gsub(str, "^%u", string.lower)
+
+	-- Handle kebab-case, snake_case, and space-separated words
+	str = string.gsub(str, "[-_%s](%w)", function(s)
+		return string.upper(s)
+	end)
+
+	return str
+end
+
+utils.notices = {}
+
+function utils.notices.credit(msg)
+	local notice = {
+		Target = msg.Recipient,
+		Action = "Credit-Notice",
+		Sender = msg.From,
+		Quantity = tostring(1),
+	}
+	for tagName, tagValue in pairs(msg) do
+		-- Tags beginning with "X-" are forwarded
+		if string.sub(tagName, 1, 2) == "X-" then
+			notice[tagName] = tagValue
+		end
+	end
+
+	return notice
+end
+
+function utils.notices.debit(msg)
+	local notice = {
+		Target = msg.From,
+		Action = "Debit-Notice",
+		Recipient = msg.Recipient,
+		Quantity = tostring(1),
+	}
+	-- Add forwarded tags to the credit and debit notice messages
+	for tagName, tagValue in pairs(msg) do
+		-- Tags beginning with "X-" are forwarded
+		if string.sub(tagName, 1, 2) == "X-" then
+			notice[tagName] = tagValue
+		end
+	end
+
+	return notice
+end
+
+-- @param notices table
+function utils.notices.sendNotices(notices)
+	for _, notice in ipairs(notices) do
+		ao.send(notice)
+	end
+end
+
+function utils.notices.notifyState(msg, target)
+	if not target then
+		print("No target specified for state notice")
+		return
+	end
+	local state = {
+		Records = Records,
+		Controllers = Controllers,
+		Balances = Balances,
+		Owner = Owner,
+		Name = Name,
+		Ticker = Ticker,
+		Logo = Logo,
+		Denomination = Denomination,
+		TotalSupply = TotalSupply,
+		Initialized = Initialized,
+		["Source-Code-TX-ID"] = SourceCodeTxId,
+	}
+
+	-- Add forwarded tags to the records notice messages
+	for tagName, tagValue in pairs(msg) do
+		-- Tags beginning with "X-" are forwarded
+		if string.sub(tagName, 1, 2) == "X-" then
+			state[tagName] = tagValue
+		end
+	end
+
+	ao.send({ Target = target, Action = "State-Notice", Data = json.encode(state) })
+end
+
+function utils.getHandlerNames(handlers)
+	local names = {}
+	for _, handler in ipairs(handlers.list) do
+		table.insert(names, handler.name)
+	end
+	return names
+end
+
+return utils
+
+end
+
+_G.package.loaded[".common.utils"] = _loaded_mod_common_utils()
+
+-- module: ".common.balances"
+local function _loaded_mod_common_balances()
+local utils = require(".common.utils")
+local json = require(".common.json")
+
+local balances = {}
+
+function balances.walletHasSufficientBalance(wallet)
+	return Balances[wallet] ~= nil and Balances[wallet] > 0
+end
+
+function balances.transfer(to)
+	utils.validateArweaveId(to)
+	Balances = { [to] = 1 }
+	Owner = to
+	Controllers = {}
+	return json.encode({ [to] = 1 })
+end
+
+function balances.balance(address)
+	utils.validateArweaveId(address)
+	local balance = Balances[address] or 0
+	return balance
+end
+
+function balances.balances()
+	return json.encode(Balances)
+end
+
+function balances.setName(name)
+	assert(type(name) == "string", "Name must be a string")
+	Name = name
+	return json.encode({ name = Name })
+end
+
+function balances.setTicker(ticker)
+	assert(type(ticker) == "string", "Ticker must be a string")
+	Ticker = ticker
+	return json.encode({ ticker = Ticker })
+end
+
+return balances
+
+end
+
+_G.package.loaded[".common.balances"] = _loaded_mod_common_balances()
+
+-- module: ".common.initialize"
+local function _loaded_mod_common_initialize()
+local utils = require(".common.utils")
+local json = require(".common.json")
+local initialize = {}
+
+function initialize.initializeANTState(state)
+	local encoded = json.decode(state)
+	local balances = encoded.balances
+	local controllers = encoded.controllers
+	local records = encoded.records
+	local name = encoded.name
+	local ticker = encoded.ticker
+	local owner = encoded.owner
+	assert(type(name) == "string", "name must be a string")
+	assert(type(ticker) == "string", "ticker must be a string")
+	assert(type(balances) == "table", "balances must be a table")
+	for k, v in pairs(balances) do
+		balances[k] = tonumber(v)
+	end
+	assert(type(controllers) == "table", "controllers must be a table")
+	assert(type(records) == "table", "records must be a table")
+	assert(type(owner) == "string", "owner must be a string")
+	for k, v in pairs(records) do
+		utils.validateUndername(k)
+		assert(type(v) == "table", "records values must be tables")
+		utils.validateArweaveId(v.transactionId)
+		utils.validateTTLSeconds(v.ttlSeconds)
+	end
+
+	Name = name
+	Ticker = ticker
+	Balances = balances
+	Controllers = controllers
+	Records = records
+	Initialized = true
+	Owner = owner
+
+	return json.encode({
+		name = Name,
+		ticker = Ticker,
+		balances = Balances,
+		controllers = Controllers,
+		records = Records,
+		owner = Owner,
+		initialized = Initialized,
+	})
+end
+
+local function findObject(array, key, value)
+	for i, object in ipairs(array) do
+		if object[key] == value then
+			return object
+		end
+	end
+	return nil
+end
+
+function initialize.initializeProcessState(msg, env)
+	Errors = Errors or {}
+	Inbox = Inbox or {}
+
+	-- temporary fix for Spawn
+	if not Owner then
+		local _from = findObject(env.Process.Tags, "name", "From-Process")
+		if _from then
+			Owner = _from.value
+		else
+			Owner = msg.From
+		end
+	end
+
+	if not Name then
+		local taggedName = findObject(env.Process.Tags, "name", "Name")
+		if taggedName then
+			Name = taggedName.value
+		else
+			Name = "ANT"
+		end
+	end
+end
+
+return initialize
+
+end
+
+_G.package.loaded[".common.initialize"] = _loaded_mod_common_initialize()
+
+-- module: ".common.records"
+local function _loaded_mod_common_records()
+local utils = require(".common.utils")
+local json = require(".common.json")
+local records = {}
+-- defaults to landing page txid
+Records = Records or { ["@"] = { transactionId = "-k7t8xMoB8hW482609Z9F4bTFMC3MnuW8bTvTyT8pFI", ttlSeconds = 3600 } }
+
+function records.setRecord(name, transactionId, ttlSeconds)
+	local nameValidity, nameValidityError = pcall(utils.validateUndername, name)
+	assert(nameValidity ~= false, nameValidityError)
+	local targetIdValidity, targetValidityError = pcall(utils.validateArweaveId, transactionId)
+	assert(targetIdValidity ~= false, targetValidityError)
+	local ttlSecondsValidity, ttlValidityError = pcall(utils.validateTTLSeconds, ttlSeconds)
+	assert(ttlSecondsValidity ~= false, ttlValidityError)
+
+	local recordsCount = #Records
+
+	if recordsCount >= 10000 then
+		error("Max records limit of 10,000 reached, please delete some records to make space")
+	end
+
+	Records[name] = {
+		transactionId = transactionId,
+		ttlSeconds = ttlSeconds,
+	}
+
+	return json.encode({
+		transactionId = transactionId,
+		ttlSeconds = ttlSeconds,
+	})
+end
+
+function records.removeRecord(name)
+	local nameValidity, nameValidityError = pcall(utils.validateUndername, name)
+	assert(nameValidity ~= false, nameValidityError)
+	Records[name] = nil
+	return json.encode({ message = "Record deleted" })
+end
+
+function records.getRecord(name)
+	utils.validateUndername(name)
+	assert(Records[name] ~= nil, "Record does not exist")
+
+	return json.encode(Records[name])
+end
+
+function records.getRecords()
+	return json.encode(Records)
+end
+
+return records
+
+end
+
+_G.package.loaded[".common.records"] = _loaded_mod_common_records()
+
+-- module: ".common.controllers"
+local function _loaded_mod_common_controllers()
+local json = require(".common.json")
+local utils = require(".common.utils")
+
+local controllers = {}
+
+function controllers.setController(controller)
+	utils.validateArweaveId(controller)
+
+	for _, c in ipairs(Controllers) do
+		assert(c ~= controller, "Controller already exists")
+	end
+
+	table.insert(Controllers, controller)
+	return json.encode(Controllers)
+end
+
+function controllers.removeController(controller)
+	utils.validateArweaveId(controller)
+	local controllerExists = false
+
+	for i, v in ipairs(Controllers) do
+		if v == controller then
+			table.remove(Controllers, i)
+			controllerExists = true
+			break
+		end
+	end
+
+	assert(controllerExists ~= nil, "Controller does not exist")
+	return json.encode(Controllers)
+end
+
+function controllers.getControllers()
+	return json.encode(Controllers)
+end
+
+return controllers
+
+end
+
+_G.package.loaded[".common.controllers"] = _loaded_mod_common_controllers()
+
+-- module: ".common.main"
+local function _loaded_mod_common_main()
+local ant = {}
+
+function ant.init()
+	-- main.lua
+	-- utils
+	local json = require(".common.json")
+	local utils = require(".common.utils")
+	local camel = utils.camelCase
+	-- spec modules
+	local balances = require(".common.balances")
+	local initialize = require(".common.initialize")
+	local records = require(".common.records")
+	local controllers = require(".common.controllers")
+
+	Owner = Owner or ao.env.Process.Owner
+	Balances = Balances or { [Owner] = 1 }
+	Controllers = Controllers or { Owner }
+
+	Name = Name or "Arweave Name Token"
+	Ticker = Ticker or "ANT"
+	Logo = Logo or "Sie_26dvgyok0PZD_-iQAFOhOd5YxDTkczOLoqTTL_A"
+	Denomination = Denomination or 0
+	TotalSupply = TotalSupply or 1
+	Initialized = Initialized or false
+	-- INSERT placeholder used by build script to inject the appropriate ID
+	SourceCodeTxId = SourceCodeTxId or "__INSERT_SOURCE_CODE_ID__"
+	AntRegistryId = AntRegistryId or ao.env.Process.Tags["ANT-Registry-Id"] or nil
+
+	local ActionMap = {
+		-- write
+		AddController = "Add-Controller",
+		RemoveController = "Remove-Controller",
+		SetRecord = "Set-Record",
+		RemoveRecord = "Remove-Record",
+		SetName = "Set-Name",
+		SetTicker = "Set-Ticker",
+		--- initialization method for bootstrapping the contract from other platforms ---
+		InitializeState = "Initialize-State",
+		-- read
+		Controllers = "Controllers",
+		Record = "Record",
+		Records = "Records",
+		State = "State",
+		Evolve = "Evolve",
+	}
+
+	local TokenSpecActionMap = {
+		Info = "Info",
+		Balances = "Balances",
+		Balance = "Balance",
+		Transfer = "Transfer",
+		TotalSupply = "Total-Supply",
+		CreditNotice = "Credit-Notice",
+		-- not implemented
+		Mint = "Mint",
+		Burn = "Burn",
+	}
+
+	Handlers.add(
+		camel(TokenSpecActionMap.Transfer),
+		utils.hasMatchingTag("Action", TokenSpecActionMap.Transfer),
+		function(msg)
+			local recipient = msg.Tags.Recipient
+			local function checkAssertions()
+				utils.validateOwner(msg.From)
+			end
+
+			local inputStatus, inputResult = pcall(checkAssertions)
+
+			if not inputStatus then
+				ao.send({
+					Target = msg.From,
+					Tags = { Action = "Invalid-Transfer-Notice", Error = "Transfer-Error" },
+					Data = tostring(inputResult),
+					["Message-Id"] = msg.Id,
+				})
+				return
+			end
+			local transferStatus, transferResult = pcall(balances.transfer, recipient)
+
+			if not transferStatus then
+				ao.send({
+					Target = msg.From,
+					Tags = { Action = "Invalid-Transfer-Notice", Error = "Transfer-Error" },
+					["Message-Id"] = msg.Id,
+					Data = tostring(transferResult),
+				})
+				return
+			elseif not msg.Cast then
+				ao.send(utils.notices.debit(msg))
+				ao.send(utils.notices.credit(msg))
+				utils.notices.notifyState(msg, AntRegistryId)
+				return
+			end
+			ao.send({
+				Target = msg.From,
+				Data = transferResult,
+			})
+			utils.notices.notifyState(msg, AntRegistryId)
+		end
+	)
+
+	Handlers.add(
+		camel(TokenSpecActionMap.Balance),
+		utils.hasMatchingTag("Action", TokenSpecActionMap.Balance),
+		function(msg)
+			local balStatus, balRes = pcall(balances.balance, msg.Tags.Recipient or msg.From)
+			if not balStatus then
+				ao.send({
+					Target = msg.From,
+					Tags = { Action = "Invalid-Balance-Notice", Error = "Balance-Error" },
+					["Message-Id"] = msg.Id,
+					Data = tostring(balRes),
+				})
+			else
+				ao.send({
+					Target = msg.From,
+					Action = "Balance-Notice",
+					Balance = tostring(balRes),
+					Ticker = Ticker,
+					Address = msg.Tags.Recipient or msg.From,
+					Data = balRes,
+				})
+			end
+		end
+	)
+
+	Handlers.add(
+		camel(TokenSpecActionMap.Balances),
+		utils.hasMatchingTag("Action", TokenSpecActionMap.Balances),
+		function(msg)
+			ao.send({
+				Target = msg.From,
+				Action = "Balances-Notice",
+				Data = balances.balances(),
+			})
+		end
+	)
+
+	Handlers.add(
+		camel(TokenSpecActionMap.TotalSupply),
+		utils.hasMatchingTag("Action", TokenSpecActionMap.TotalSupply),
+		function(msg)
+			assert(msg.From ~= ao.id, "Cannot call Total-Supply from the same process!")
+
+			ao.send({
+				Target = msg.From,
+				Action = "Total-Supply-Notice",
+				Data = TotalSupply,
+				Ticker = Ticker,
+			})
+		end
+	)
+
+	Handlers.add(camel(TokenSpecActionMap.Info), utils.hasMatchingTag("Action", TokenSpecActionMap.Info), function(msg)
+		local info = {
+			Name = Name,
+			Ticker = Ticker,
+			["Total-Supply"] = tostring(TotalSupply),
+			Logo = Logo,
+			Denomination = tostring(Denomination),
+			Owner = Owner,
+			Handlers = utils.getHandlerNames(Handlers),
+			["Source-Code-TX-ID"] = SourceCodeTxId,
+		}
+		ao.send({
+			Target = msg.From,
+			Action = "Info-Notice",
+			Tags = info,
+			Data = json.encode(info),
+		})
+	end)
+
+	-- ActionMap (ANT Spec)
+
+	Handlers.add(camel(ActionMap.AddController), utils.hasMatchingTag("Action", ActionMap.AddController), function(msg)
+		local assertHasPermission, permissionErr = pcall(utils.assertHasPermission, msg.From)
+		if assertHasPermission == false then
+			return ao.send({
+				Target = msg.From,
+				Action = "Invalid-Add-Controller-Notice",
+				Error = "Add-Controller-Error",
+				["Message-Id"] = msg.Id,
+				Data = permissionErr,
+			})
+		end
+		local controllerStatus, controllerRes = pcall(controllers.setController, msg.Tags.Controller)
+		if not controllerStatus then
+			ao.send({
+				Target = msg.From,
+				Action = "Invalid-Add-Controller-Notice",
+				Error = "Add-Controller-Error",
+				["Message-Id"] = msg.Id,
+				Data = controllerRes,
+			})
+			return
+		end
+		ao.send({ Target = msg.From, Action = "Add-Controller-Notice", Data = controllerRes })
+		utils.notices.notifyState(msg, AntRegistryId)
+	end)
+
+	Handlers.add(
+		camel(ActionMap.RemoveController),
+		utils.hasMatchingTag("Action", ActionMap.RemoveController),
+		function(msg)
+			local assertHasPermission, permissionErr = pcall(utils.assertHasPermission, msg.From)
+			if assertHasPermission == false then
+				return ao.send({
+					Target = msg.From,
+					Action = "Invalid-Remove-Controller-Notice",
+					Data = permissionErr,
+					Error = "Remove-Controller-Error",
+					["Message-Id"] = msg.Id,
+				})
+			end
+			local removeStatus, removeRes = pcall(controllers.removeController, msg.Tags.Controller)
+			if not removeStatus then
+				ao.send({
+					Target = msg.From,
+					Action = "Invalid-Remove-Controller-Notice",
+					Data = removeRes,
+					Error = "Remove-Controller-Error",
+					["Message-Id"] = msg.Id,
+				})
+				return
+			end
+
+			ao.send({ Target = msg.From, Action = "Remove-Controller-Notice", Data = removeRes })
+			utils.notices.notifyState(msg, AntRegistryId)
+		end
+	)
+
+	Handlers.add(camel(ActionMap.Controllers), utils.hasMatchingTag("Action", ActionMap.Controllers), function(msg)
+		ao.send({ Target = msg.From, Action = "Controllers-Notice", Data = controllers.getControllers() })
+	end)
+
+	Handlers.add(camel(ActionMap.SetRecord), utils.hasMatchingTag("Action", ActionMap.SetRecord), function(msg)
+		local assertHasPermission, permissionErr = pcall(utils.assertHasPermission, msg.From)
+		if assertHasPermission == false then
+			return ao.send({
+				Target = msg.From,
+				Action = "Invalid-Set-Record-Notice",
+				Data = permissionErr,
+				Error = "Set-Record-Error",
+				["Message-Id"] = msg.Id,
+			})
+		end
+		local tags = msg.Tags
+		local name, transactionId, ttlSeconds =
+			string.lower(tags["Sub-Domain"]), tags["Transaction-Id"], tonumber(tags["TTL-Seconds"])
+
+		local setRecordStatus, setRecordResult = pcall(records.setRecord, name, transactionId, ttlSeconds)
+		if not setRecordStatus then
+			ao.send({
+				Target = msg.From,
+				Action = "Invalid-Set-Record-Notice",
+				Data = setRecordResult,
+				Error = "Set-Record-Error",
+				["Message-Id"] = msg.Id,
+			})
+			return
+		end
+
+		ao.send({ Target = msg.From, Action = "Set-Record-Notice", Data = setRecordResult })
+	end)
+
+	Handlers.add(camel(ActionMap.RemoveRecord), utils.hasMatchingTag("Action", ActionMap.RemoveRecord), function(msg)
+		local assertHasPermission, permissionErr = pcall(utils.assertHasPermission, msg.From)
+		if assertHasPermission == false then
+			return ao.send({ Target = msg.From, Action = "Invalid-Remove-Record-Notice", Data = permissionErr })
+		end
+		local name = string.lower(msg.Tags["Sub-Domain"])
+		local removeRecordStatus, removeRecordResult = pcall(records.removeRecord, name)
+		if not removeRecordStatus then
+			ao.send({
+				Target = msg.From,
+				Action = "Invalid-Remove-Record-Notice",
+				Data = removeRecordResult,
+				Error = "Remove-Record-Error",
+				["Message-Id"] = msg.Id,
+			})
+		else
+			ao.send({ Target = msg.From, Data = removeRecordResult })
+		end
+	end)
+
+	Handlers.add(camel(ActionMap.Record), utils.hasMatchingTag("Action", ActionMap.Record), function(msg)
+		local name = string.lower(msg.Tags["Sub-Domain"])
+		local nameStatus, nameRes = pcall(records.getRecord, name)
+		if not nameStatus then
+			ao.send({
+				Target = msg.From,
+				Action = "Invalid-Record-Notice",
+				Data = nameRes,
+				Error = "Record-Error",
+				["Message-Id"] = msg.Id,
+			})
+			return
+		end
+
+		local recordNotice = {
+			Target = msg.From,
+			Action = "Record-Notice",
+			Name = name,
+			Data = nameRes,
+		}
+
+		-- Add forwarded tags to the credit and debit notice messages
+		for tagName, tagValue in pairs(msg) do
+			-- Tags beginning with "X-" are forwarded
+			if string.sub(tagName, 1, 2) == "X-" then
+				recordNotice[tagName] = tagValue
+			end
+		end
+
+		-- Send Record-Notice
+		ao.send(recordNotice)
+	end)
+
+	Handlers.add(camel(ActionMap.Records), utils.hasMatchingTag("Action", ActionMap.Records), function(msg)
+		local records = records.getRecords()
+
+		-- Credit-Notice message template, that is sent to the Recipient of the transfer
+		local recordsNotice = {
+			Target = msg.From,
+			Action = "Records-Notice",
+			Data = records,
+		}
+
+		-- Add forwarded tags to the records notice messages
+		for tagName, tagValue in pairs(msg) do
+			-- Tags beginning with "X-" are forwarded
+			if string.sub(tagName, 1, 2) == "X-" then
+				recordsNotice[tagName] = tagValue
+			end
+		end
+
+		-- Send Records-Notice
+		ao.send(recordsNotice)
+	end)
+
+	Handlers.add(camel(ActionMap.SetName), utils.hasMatchingTag("Action", ActionMap.SetName), function(msg)
+		local assertHasPermission, permissionErr = pcall(utils.assertHasPermission, msg.From)
+		if assertHasPermission == false then
+			return ao.send({
+				Target = msg.From,
+				Action = "Invalid-Set-Name-Notice",
+				Data = permissionErr,
+				Error = "Set-Name-Error",
+				["Message-Id"] = msg.Id,
+			})
+		end
+		local nameStatus, nameRes = pcall(balances.setName, msg.Tags.Name)
+		if not nameStatus then
+			ao.send({
+				Target = msg.From,
+				Action = "Invalid-Set-Name-Notice",
+				Data = nameRes,
+				Error = "Set-Name-Error",
+				["Message-Id"] = msg.Id,
+			})
+			return
+		end
+		ao.send({ Target = msg.From, Action = "Set-Name-Notice", Data = nameRes })
+	end)
+
+	Handlers.add(camel(ActionMap.SetTicker), utils.hasMatchingTag("Action", ActionMap.SetTicker), function(msg)
+		local assertHasPermission, permissionErr = pcall(utils.assertHasPermission, msg.From)
+		if assertHasPermission == false then
+			return ao.send({
+				Target = msg.From,
+				Action = "Invalid-Set-Ticker-Notice",
+				Data = permissionErr,
+				Error = "Set-Ticker-Error",
+				["Message-Id"] = msg.Id,
+			})
+		end
+		local tickerStatus, tickerRes = pcall(balances.setTicker, msg.Tags.Ticker)
+		if not tickerStatus then
+			ao.send({
+				Target = msg.From,
+				Action = "Invalid-Set-Ticker-Notice",
+				Data = tickerRes,
+				Error = "Set-Ticker-Error",
+				["Message-Id"] = msg.Id,
+			})
+			return
+		end
+
+		ao.send({ Target = msg.From, Action = "Set-Ticker-Notice", Data = tickerRes })
+	end)
+
+	Handlers.add(
+		camel(ActionMap.InitializeState),
+		utils.hasMatchingTag("Action", ActionMap.InitializeState),
+		function(msg)
+			assert(msg.From == Owner, "Only the owner can initialize the state")
+			local initStatus, result = pcall(initialize.initializeANTState, msg.Data)
+
+			if not initStatus then
+				ao.send({
+					Target = msg.From,
+					Action = "Invalid-Initialize-State-Notice",
+					Data = result,
+					Error = "Initialize-State-Error",
+					["Message-Id"] = msg.Id,
+				})
+				return
+			else
+				ao.send({ Target = msg.From, Action = "Initialize-State-Notice", Data = result })
+				utils.notices.notifyState(msg, AntRegistryId)
+			end
+		end
+	)
+	Handlers.add(camel(ActionMap.State), utils.hasMatchingTag("Action", ActionMap.State), function(msg)
+		utils.notices.notifyState(msg, msg.From)
+	end)
+
+	Handlers.prepend(
+		camel(ActionMap.Evolve),
+		Handlers.utils.continue(utils.hasMatchingTag("Action", "Eval")),
+		function(msg)
+			local srcCodeTxId = msg.Tags["Source-Code-TX-ID"]
+			if not srcCodeTxId then
+				return
+			end
+
+			if Owner ~= msg.From then
+				ao.send({
+					Target = msg.From,
+					Action = "Invalid-Evolve-Notice",
+					Error = "Evolve-Error",
+					["Message-Id"] = msg.Id,
+					Data = "Only the Owner [" .. Owner or "no owner set" .. "] can call Evolve",
+				})
+				return
+			end
+
+			local srcCodeTxIdStatus, srcCodeTxIdResult = pcall(utils.validateArweaveId, srcCodeTxId)
+			if srcCodeTxIdStatus and not srcCodeTxIdStatus then
+				ao.send({
+					Target = msg.From,
+					Action = "Invalid-Evolve-Notice",
+					Error = "Evolve-Error",
+					["Message-Id"] = msg.Id,
+					Data = "Source-Code-TX-ID is required",
+				})
+				return
+			end
+			SourceCodeTxId = srcCodeTxId
+		end
+	)
+end
+
+return ant
+
+end
+
+_G.package.loaded[".common.main"] = _loaded_mod_common_main()
+
+local ant = require(".common.main")
+
+ant.init()

--- a/process/eval.lua
+++ b/process/eval.lua
@@ -1,38 +1,39 @@
 local stringify = require(".stringify")
 -- handler for eval
-return function (ao)
-  return function (msg)
-    -- exec expression
-    local expr = msg.Data
-    local func, err = load("return " .. expr, 'aos', 't', _G)
-    local output = ""
-    local e = nil
-    if err then
-      func, err = load(expr, 'aos', 't', _G)
-    end
-    if func then
-      output, e = func()
-    else
-      ao.outbox.Error = err
-      return
-    end
-    if e then 
-      ao.outbox.Error = e
-      return 
-    end
-    if HANDLER_PRINT_LOGS and output then
-      table.insert(HANDLER_PRINT_LOGS, type(output) == "table" and stringify.format(output) or tostring(output))
-    else 
-      -- set result in outbox.Output (Left for backwards compatibility)
-      ao.outbox.Output = {  
-        json = type(output) == "table" and pcall(function () return json.encode(output) end) and output or "undefined",
-        data = {
-          output = type(output) == "table" and stringify.format(output) or output,
-          prompt = Prompt()
-        }, 
-        prompt = Prompt() 
-      }
-
-    end
-  end 
+return function(ao)
+	return function(msg)
+		-- exec expression
+		local expr = msg.Data
+		local func, err = load("return " .. expr, expr, "t", _G)
+		local output = ""
+		local e = nil
+		if err then
+			func, err = load(expr, expr, "t", _G)
+		end
+		if func then
+			output, e = func()
+		else
+			ao.outbox.Error = err
+			return
+		end
+		if e then
+			ao.outbox.Error = e
+			return
+		end
+		if HANDLER_PRINT_LOGS and output then
+			table.insert(HANDLER_PRINT_LOGS, type(output) == "table" and stringify.format(output) or tostring(output))
+		else
+			-- set result in outbox.Output (Left for backwards compatibility)
+			ao.outbox.Output = {
+				json = type(output) == "table" and pcall(function()
+					return json.encode(output)
+				end) and output or "undefined",
+				data = {
+					output = type(output) == "table" and stringify.format(output) or output,
+					prompt = Prompt(),
+				},
+				prompt = Prompt(),
+			}
+		end
+	end
 end

--- a/process/process.lua
+++ b/process/process.lua
@@ -1,32 +1,34 @@
-local pretty = require('.pretty')
-local base64 = require('.base64')
-local json = require('json')
-local chance = require('.chance')
-local crypto = require('.crypto.init')
-local coroutine = require('coroutine')
+local pretty = require(".pretty")
+local base64 = require(".base64")
+local json = require("json")
+local chance = require(".chance")
+local crypto = require(".crypto.init")
+local coroutine = require("coroutine")
 -- set alias ao for .ao library
-if not _G.package.loaded['ao'] then _G.package.loaded['ao'] = require('.ao') end
+if not _G.package.loaded["ao"] then
+	_G.package.loaded["ao"] = require(".ao")
+end
 
 Colors = {
-  red = "\27[31m",
-  green = "\27[32m",
-  blue = "\27[34m",
-  reset = "\27[0m",
-  gray = "\27[90m"
+	red = "\27[31m",
+	green = "\27[32m",
+	blue = "\27[34m",
+	reset = "\27[0m",
+	gray = "\27[90m",
 }
 
 Bell = "\x07"
 
-Dump = require('.dump')
-Utils = require('.utils')
-Handlers = require('.handlers')
+Dump = require(".dump")
+Utils = require(".utils")
+Handlers = require(".handlers")
 local stringify = require(".stringify")
-local assignment = require('.assignment')
+local assignment = require(".assignment")
 ao = nil
-if _G.package.loaded['.ao'] then
-  ao = require('.ao')
-elseif _G.package.loaded['ao'] then
-  ao = require('ao')
+if _G.package.loaded[".ao"] then
+	ao = require(".ao")
+elseif _G.package.loaded["ao"] then
+	ao = require("ao")
 end
 -- Implement assignable polyfills on _ao
 assignment.init(ao)
@@ -35,386 +37,406 @@ local process = { _version = "2.0.0" }
 local maxInboxCount = 10000
 
 -- wrap ao.send and ao.spawn for magic table
-local aosend = ao.send 
+local aosend = ao.send
 local aospawn = ao.spawn
-ao.send = function (msg)
-  if msg.Data and type(msg.Data) == 'table' then
-    msg['Content-Type'] = 'application/json'
-    msg.Data = require('json').encode(msg.Data)
-  end
-  return aosend(msg)
+ao.send = function(msg)
+	if msg.Data and type(msg.Data) == "table" then
+		msg["Content-Type"] = "application/json"
+		msg.Data = require("json").encode(msg.Data)
+	end
+	return aosend(msg)
 end
-ao.spawn = function (module, msg) 
-  if msg.Data and type(msg.Data) == 'table' then
-    msg['Content-Type'] = 'application/json'
-    msg.Data = require('json').encode(msg.Data)
-  end
-  return aospawn(module, msg)
+ao.spawn = function(module, msg)
+	if msg.Data and type(msg.Data) == "table" then
+		msg["Content-Type"] = "application/json"
+		msg.Data = require("json").encode(msg.Data)
+	end
+	return aospawn(module, msg)
 end
 
 local function removeLastThreeLines(input)
-  local lines = {}
-  for line in input:gmatch("([^\n]*)\n?") do
-      table.insert(lines, line)
-  end
+	local lines = {}
+	for line in input:gmatch("([^\n]*)\n?") do
+		table.insert(lines, line)
+	end
 
-  -- Remove the last three lines
-  for i = 1, 3 do
-      table.remove(lines)
-  end
+	-- Remove the last three lines
+	for i = 1, 3 do
+		table.remove(lines)
+	end
 
-  -- Concatenate the remaining lines
-  return table.concat(lines, "\n")
+	-- Concatenate the remaining lines
+	return table.concat(lines, "\n")
 end
 
-
 local function insertInbox(msg)
-  table.insert(Inbox, msg)
-  if #Inbox > maxInboxCount then
-    local overflow = #Inbox - maxInboxCount 
-    for i = 1,overflow do
-      table.remove(Inbox, 1)
-    end
-  end 
+	table.insert(Inbox, msg)
+	if #Inbox > maxInboxCount then
+		local overflow = #Inbox - maxInboxCount
+		for i = 1, overflow do
+			table.remove(Inbox, 1)
+		end
+	end
 end
 
 local function findObject(array, key, value)
-  for i, object in ipairs(array) do
-    if object[key] == value then
-      return object
-    end
-  end
-  return nil
+	for i, object in ipairs(array) do
+		if object[key] == value then
+			return object
+		end
+	end
+	return nil
 end
 
 function Tab(msg)
-  local inputs = {}
-  for _, o in ipairs(msg.Tags) do
-    if not inputs[o.name] then
-      inputs[o.name] = o.value
-    end
-  end
-  return inputs
+	local inputs = {}
+	for _, o in ipairs(msg.Tags) do
+		if not inputs[o.name] then
+			inputs[o.name] = o.value
+		end
+	end
+	return inputs
 end
 
 function Prompt()
-  return Colors.green .. Name .. Colors.gray
-    .. "@" .. Colors.blue .. "aos-" .. process._version .. Colors.gray
-    .. "[Inbox:" .. Colors.red .. tostring(#Inbox) .. Colors.gray
-    .. "]" .. Colors.reset .. "> "
+	return Colors.green
+		.. Name
+		.. Colors.gray
+		.. "@"
+		.. Colors.blue
+		.. "aos-"
+		.. process._version
+		.. Colors.gray
+		.. "[Inbox:"
+		.. Colors.red
+		.. tostring(#Inbox)
+		.. Colors.gray
+		.. "]"
+		.. Colors.reset
+		.. "> "
 end
 
 function print(a)
-  if type(a) == "table" then
-    a = stringify.format(a)
-  end
-  --[[
+	if type(a) == "table" then
+		a = stringify.format(a)
+	end
+	--[[
 In order to print non string types we need to convert to string
   ]]
-  if type(a) == "boolean" then
-    a = Colors.blue .. tostring(a) .. Colors.reset
-  end
-  if type(a) == "nil" then
-    a = Colors.red .. tostring(a) .. Colors.reset
-  end
-  if type(a) == "number" then
-    a = Colors.green .. tostring(a) .. Colors.reset
-  end
-  
-  local data = a
-  if ao.outbox.Output.data then
-    data =  ao.outbox.Output.data .. "\n" .. a
-  end
-  ao.outbox.Output = { data = data, prompt = Prompt(), print = true }
+	if type(a) == "boolean" then
+		a = Colors.blue .. tostring(a) .. Colors.reset
+	end
+	if type(a) == "nil" then
+		a = Colors.red .. tostring(a) .. Colors.reset
+	end
+	if type(a) == "number" then
+		a = Colors.green .. tostring(a) .. Colors.reset
+	end
 
-  -- Only supported for newer version of AOS
-  if HANDLER_PRINT_LOGS then 
-    table.insert(HANDLER_PRINT_LOGS, a)
-    return nil
-  end
+	local data = a
+	if ao.outbox.Output.data then
+		data = ao.outbox.Output.data .. "\n" .. a
+	end
+	ao.outbox.Output = { data = data, prompt = Prompt(), print = true }
 
-  return tostring(a)
+	-- Only supported for newer version of AOS
+	if HANDLER_PRINT_LOGS then
+		table.insert(HANDLER_PRINT_LOGS, a)
+		return nil
+	end
+
+	return tostring(a)
 end
 
 function Send(msg)
-  if not msg.Target then
-    print("WARN: No target specified for message. Data will be stored, but no process will receive it.")
-  end
-  local result = ao.send(msg)
-  return {
-    output = "Message added to outbox",
-    receive = result.receive,
-    onReply = result.onReply
-  }
+	if not msg.Target then
+		print("WARN: No target specified for message. Data will be stored, but no process will receive it.")
+	end
+	local result = ao.send(msg)
+	return {
+		output = "Message added to outbox",
+		receive = result.receive,
+		onReply = result.onReply,
+	}
 end
 
 function Spawn(...)
-  local module, spawnMsg
+	local module, spawnMsg
 
-  if select("#", ...) == 1 then
-    spawnMsg = select(1, ...)
-    module = ao._module
-  else
-    module = select(1, ...)
-    spawnMsg = select(2, ...)
-  end
+	if select("#", ...) == 1 then
+		spawnMsg = select(1, ...)
+		module = ao._module
+	else
+		module = select(1, ...)
+		spawnMsg = select(2, ...)
+	end
 
-  if not spawnMsg then
-    spawnMsg = {}
-  end
-  local result = ao.spawn(module, spawnMsg)
-  return {
-    output = "Spawn process request added to outbox",
-    after = result.after,
-    receive = result.receive
-  }  
+	if not spawnMsg then
+		spawnMsg = {}
+	end
+	local result = ao.spawn(module, spawnMsg)
+	return {
+		output = "Spawn process request added to outbox",
+		after = result.after,
+		receive = result.receive,
+	}
 end
 
 function Receive(match)
-  return Handlers.receive(match)
+	return Handlers.receive(match)
 end
 
 function Assign(assignment)
-  if not ao.assign then
-    print("Assign is not implemented.")
-    return "Assign is not implemented."
-  end
-  ao.assign(assignment)
-  print("Assignment added to outbox.")
-  return 'Assignment added to outbox.'
+	if not ao.assign then
+		print("Assign is not implemented.")
+		return "Assign is not implemented."
+	end
+	ao.assign(assignment)
+	print("Assignment added to outbox.")
+	return "Assignment added to outbox."
 end
 
 Seeded = Seeded or false
 
 -- this is a temporary approach...
 local function stringToSeed(s)
-  local seed = 0
-  for i = 1, #s do
-      local char = string.byte(s, i)
-      seed = seed + char
-  end
-  return seed
+	local seed = 0
+	for i = 1, #s do
+		local char = string.byte(s, i)
+		seed = seed + char
+	end
+	return seed
 end
 
 local function initializeState(msg, env)
-  if not Seeded then
-    --math.randomseed(1234)
-    chance.seed(tonumber(msg['Block-Height'] .. stringToSeed(msg.Owner .. msg.Module .. msg.Id)))
-    math.random = function (...)
-      local args = {...}
-      local n = #args
-      if n == 0 then
-        return chance.random()
-      end
-      if n == 1 then
-        return chance.integer(1, args[1])
-      end
-      if n == 2 then
-        return chance.integer(args[1], args[2])
-      end
-      return chance.random()
-    end
-    Seeded = true
-  end
-  Errors = Errors or {}
-  Inbox = Inbox or {}
+	if not Seeded then
+		--math.randomseed(1234)
+		chance.seed(tonumber(msg["Block-Height"] .. stringToSeed(msg.Owner .. msg.Module .. msg.Id)))
+		math.random = function(...)
+			local args = { ... }
+			local n = #args
+			if n == 0 then
+				return chance.random()
+			end
+			if n == 1 then
+				return chance.integer(1, args[1])
+			end
+			if n == 2 then
+				return chance.integer(args[1], args[2])
+			end
+			return chance.random()
+		end
+		Seeded = true
+	end
+	Errors = Errors or {}
+	Inbox = Inbox or {}
 
-  -- temporary fix for Spawn
-  if not Owner then
-    local _from = findObject(env.Process.Tags, "name", "From-Process")
-    if _from then
-      Owner = _from.value
-    else
-      Owner = msg.From
-    end
-  end
+	-- temporary fix for Spawn
+	if not Owner then
+		local _from = findObject(env.Process.Tags, "name", "From-Process")
+		if _from then
+			Owner = _from.value
+		else
+			Owner = msg.From
+		end
+	end
 
-  if not Name then
-    local aosName = findObject(env.Process.Tags, "name", "Name")
-    if aosName then
-      Name = aosName.value
-    else
-      Name = 'aos'
-    end
-  end
-
+	if not Name then
+		local aosName = findObject(env.Process.Tags, "name", "Name")
+		if aosName then
+			Name = aosName.value
+		else
+			Name = "aos"
+		end
+	end
 end
 
 function Version()
-  print("version: " .. process._version)
+	print("version: " .. process._version)
 end
 
 function process.handle(msg, _)
-  local env = nil
-  if _.Process then
-    env = _
-  else
-    env = _.env
-  end
-  
-  ao.init(env)
-  -- relocate custom tags to root message
-  msg = ao.normalize(msg)
-  -- set process id
-  ao.id = ao.env.Process.Id
-  initializeState(msg, ao.env)
-  HANDLER_PRINT_LOGS = {}
-  
-  -- set os.time to return msg.Timestamp
-  os.time = function () return msg.Timestamp end
+	local env = nil
+	if _.Process then
+		env = _
+	else
+		env = _.env
+	end
 
-  -- tagify msg
-  msg.TagArray = msg.Tags
-  msg.Tags = Tab(msg)
-  -- tagify Process
-  ao.env.Process.TagArray = ao.env.Process.Tags
-  ao.env.Process.Tags = Tab(ao.env.Process)
-  -- magic table - if Content-Type == application/json - decode msg.Data to a Table
-  if msg.Tags['Content-Type'] and msg.Tags['Content-Type'] == 'application/json' then
-    msg.Data = require('json').decode(msg.Data or "{}")
-  end
-  -- init Errors
-  Errors = Errors or {}
-  -- clear Outbox
-  ao.clearOutbox()
+	ao.init(env)
+	-- relocate custom tags to root message
+	msg = ao.normalize(msg)
+	-- set process id
+	ao.id = ao.env.Process.Id
+	initializeState(msg, ao.env)
+	HANDLER_PRINT_LOGS = {}
 
-  -- Only trust messages from a signed owner or an Authority
-  if msg.From ~= msg.Owner and not ao.isTrusted(msg) then
-    if msg.From ~= ao.id then
-      Send({Target = msg.From, Data = "Message is not trusted by this process!"})
-    end
-    print('Message is not trusted! From: ' .. msg.From .. ' - Owner: ' .. msg.Owner)
-    return ao.result({ }) 
-  end
+	-- set os.time to return msg.Timestamp
+	os.time = function()
+		return msg.Timestamp
+	end
 
-  if ao.isAssignment(msg) and not ao.isAssignable(msg) then
-    if msg.From ~= ao.id then
-      Send({Target = msg.From, Data = "Assignment is not trusted by this process!"})
-    end
-    print('Assignment is not trusted! From: ' .. msg.From .. ' - Owner: ' .. msg.Owner)
-    return ao.result({ })
-  end
+	-- tagify msg
+	msg.TagArray = msg.Tags
+	msg.Tags = Tab(msg)
+	-- tagify Process
+	ao.env.Process.TagArray = ao.env.Process.Tags
+	ao.env.Process.Tags = Tab(ao.env.Process)
+	-- magic table - if Content-Type == application/json - decode msg.Data to a Table
+	if msg.Tags["Content-Type"] and msg.Tags["Content-Type"] == "application/json" then
+		msg.Data = require("json").decode(msg.Data or "{}")
+	end
+	-- init Errors
+	Errors = Errors or {}
+	-- clear Outbox
+	ao.clearOutbox()
 
-  Handlers.add("_eval",
-    function (msg)
-      return msg.Action == "Eval" and Owner == msg.From
-    end,
-    require('.eval')(ao)
-  )
+	-- Only trust messages from a signed owner or an Authority
+	if msg.From ~= msg.Owner and not ao.isTrusted(msg) then
+		if msg.From ~= ao.id then
+			Send({ Target = msg.From, Data = "Message is not trusted by this process!" })
+		end
+		print("Message is not trusted! From: " .. msg.From .. " - Owner: " .. msg.Owner)
+		return ao.result({})
+	end
 
-  -- Added for aop6 boot loader
-  -- See: https://github.com/permaweb/aos/issues/342
-  Handlers.once("_boot",
-    function (msg)
-      return msg.Tags.Type == "Process" and Owner == msg.From
-    end,
-    require('.boot')(ao)
-  )
+	if ao.isAssignment(msg) and not ao.isAssignable(msg) then
+		if msg.From ~= ao.id then
+			Send({ Target = msg.From, Data = "Assignment is not trusted by this process!" })
+		end
+		print("Assignment is not trusted! From: " .. msg.From .. " - Owner: " .. msg.Owner)
+		return ao.result({})
+	end
 
-  Handlers.append("_default", function () return true end, require('.default')(insertInbox))
+	Handlers.add("_eval", function(msg)
+		return msg.Action == "Eval" and Owner == msg.From
+	end, require(".eval")(ao))
 
-  -- call evaluate from handlers passing env
-  msg.reply =
-    function(replyMsg)
-      replyMsg.Target = msg["Reply-To"] or (replyMsg.Target or msg.From)
-      replyMsg["X-Reference"] = msg["X-Reference"] or msg.Reference
-      replyMsg["X-Origin"] = msg["X-Origin"] or nil
+	Handlers.add("_programState", {Action = "Program-State"}, function(m)
+		m.reply({
+			Action = "Program-State-Notice",
+			Data = json.encode(require(".utils").getProgramState())
+		})
+	end)
 
-      return ao.send(replyMsg)
-    end
-  
-  msg.forward =
-    function(target, forwardMsg)
-      -- Clone the message and add forwardMsg tags
-      local newMsg =  ao.sanitize(msg)
-      forwardMsg = forwardMsg or {}
+	-- Added for aop6 boot loader
+	-- See: https://github.com/permaweb/aos/issues/342
+	Handlers.once("_boot", function(msg)
+		return msg.Tags.Type == "Process" and Owner == msg.From
+	end, require(".boot")(ao))
 
-      for k,v in pairs(forwardMsg) do
-        newMsg[k] = v
-      end
+	Handlers.append("_default", function()
+		return true
+	end, require(".default")(insertInbox))
 
-      -- Set forward-specific tags
-      newMsg.Target = target
-      newMsg["Reply-To"] = msg["Reply-To"] or msg.From
-      newMsg["X-Reference"] = msg["X-Reference"] or msg.Reference
-      newMsg["X-Origin"] = msg["X-Origin"] or msg.From
-      -- clear functions
-      newMsg.reply = nil
-      newMsg.forward = nil 
-      
-      ao.send(newMsg)
-    end
+	-- call evaluate from handlers passing env
+	msg.reply = function(replyMsg)
+		replyMsg.Target = msg["Reply-To"] or (replyMsg.Target or msg.From)
+		replyMsg["X-Reference"] = msg["X-Reference"] or msg.Reference
+		replyMsg["X-Origin"] = msg["X-Origin"] or nil
 
-  local co = coroutine.create(
-    function()
-      return pcall(Handlers.evaluate, msg, env)
-    end
-  )
-  local _, status, result = coroutine.resume(co)
+		return ao.send(replyMsg)
+	end
 
-  -- Make sure we have a reference to the coroutine if it will wake up.
-  -- Simultaneously, prune any dead coroutines so that they can be
-  -- freed by the garbage collector.
-  table.insert(Handlers.coroutines, co)
-  for i, x in ipairs(Handlers.coroutines) do
-    if coroutine.status(x) == "dead" then
-      table.remove(Handlers.coroutines, i)
-    end
-  end
+	msg.forward = function(target, forwardMsg)
+		-- Clone the message and add forwardMsg tags
+		local newMsg = ao.sanitize(msg)
+		forwardMsg = forwardMsg or {}
 
-  if not status then
-    if (msg.Action == "Eval") then
-      table.insert(Errors, result)
-      local printData = table.concat(HANDLER_PRINT_LOGS, "\n")
-      return { Error = printData .. '\n\n' .. Colors.red .. 'error:\n' .. Colors.reset .. result }
-    end 
-    --table.insert(Errors, result)
-    --ao.outbox.Output.data = ""
-    if msg.Action then
-      print(Colors.red .. "Error" .. Colors.gray .. " handling message with Action = " .. msg.Action  .. Colors.reset)
-    else
-      print(Colors.red .. "Error" .. Colors.gray .. " handling message " .. Colors.reset)
-    end
-    print(Colors.green .. result .. Colors.reset)
-    print("\n" .. Colors.gray .. removeLastThreeLines(debug.traceback()) .. Colors.reset)
-    local printData = table.concat(HANDLER_PRINT_LOGS, "\n")
-    return ao.result({Error = printData .. '\n\n' .. Colors.red .. 'error:\n' .. Colors.reset .. result, Messages = {}, Spawns = {}, Assignments = {} })
-  end
-  
-  if msg.Action == "Eval" then
-    local response = ao.result({ 
-      Output = {
-        data = table.concat(HANDLER_PRINT_LOGS, "\n"),
-        prompt = Prompt(),
-        test = Dump(HANDLER_PRINT_LOGS)
-      }
-    })
-    HANDLER_PRINT_LOGS = {} -- clear logs
-    return response
-  elseif msg.Tags.Type == "Process" and Owner == msg.From then 
-    local response = nil
-  
-    -- detect if there was any output from the boot loader call
-    for _, value in pairs(HANDLER_PRINT_LOGS) do
-      if value ~= "" then
-        -- there was output from the Boot Loader eval so we want to print it
-        response = ao.result({ Output = { data = table.concat(HANDLER_PRINT_LOGS, "\n"), prompt = Prompt(), print = true } })
-        break
-      end
-    end
-  
-    if response == nil then 
-      -- there was no output from the Boot Loader eval, so we shouldn't print it
-      response = ao.result({ Output = { data = "", prompt = Prompt() } })
-    end
+		for k, v in pairs(forwardMsg) do
+			newMsg[k] = v
+		end
 
-    HANDLER_PRINT_LOGS = {} -- clear logs
-    return response
-  else
-    local response = ao.result({ Output = { data = table.concat(HANDLER_PRINT_LOGS, "\n"), prompt = Prompt(), print = true } })
-    HANDLER_PRINT_LOGS = {} -- clear logs
-    return response
-  end
+		-- Set forward-specific tags
+		newMsg.Target = target
+		newMsg["Reply-To"] = msg["Reply-To"] or msg.From
+		newMsg["X-Reference"] = msg["X-Reference"] or msg.Reference
+		newMsg["X-Origin"] = msg["X-Origin"] or msg.From
+		-- clear functions
+		newMsg.reply = nil
+		newMsg.forward = nil
+
+		ao.send(newMsg)
+	end
+
+	local co = coroutine.create(function()
+		return pcall(Handlers.evaluate, msg, env)
+	end)
+	local _, status, result = coroutine.resume(co)
+
+	-- Make sure we have a reference to the coroutine if it will wake up.
+	-- Simultaneously, prune any dead coroutines so that they can be
+	-- freed by the garbage collector.
+	table.insert(Handlers.coroutines, co)
+	for i, x in ipairs(Handlers.coroutines) do
+		if coroutine.status(x) == "dead" then
+			table.remove(Handlers.coroutines, i)
+		end
+	end
+
+	if not status then
+		if msg.Action == "Eval" then
+			table.insert(Errors, result)
+			local printData = table.concat(HANDLER_PRINT_LOGS, "\n")
+			return { Error = printData .. "\n\n" .. Colors.red .. "error:\n" .. Colors.reset .. result }
+		end
+		--table.insert(Errors, result)
+		--ao.outbox.Output.data = ""
+		if msg.Action then
+			print(
+				Colors.red .. "Error" .. Colors.gray .. " handling message with Action = " .. msg.Action .. Colors.reset
+			)
+		else
+			print(Colors.red .. "Error" .. Colors.gray .. " handling message " .. Colors.reset)
+		end
+		print(Colors.green .. result .. Colors.reset)
+		print("\n" .. Colors.gray .. removeLastThreeLines(debug.traceback()) .. Colors.reset)
+		local printData = table.concat(HANDLER_PRINT_LOGS, "\n")
+		return ao.result({
+			Error = printData .. "\n\n" .. Colors.red .. "error:\n" .. Colors.reset .. result,
+			Messages = {},
+			Spawns = {},
+			Assignments = {},
+		})
+	end
+
+	if msg.Action == "Eval" then
+		local response = ao.result({
+			Output = {
+				data = table.concat(HANDLER_PRINT_LOGS, "\n"),
+				prompt = Prompt(),
+				test = Dump(HANDLER_PRINT_LOGS),
+			},
+		})
+		HANDLER_PRINT_LOGS = {} -- clear logs
+		return response
+	elseif msg.Tags.Type == "Process" and Owner == msg.From then
+		local response = nil
+
+		-- detect if there was any output from the boot loader call
+		for _, value in pairs(HANDLER_PRINT_LOGS) do
+			if value ~= "" then
+				-- there was output from the Boot Loader eval so we want to print it
+				response = ao.result({
+					Output = { data = table.concat(HANDLER_PRINT_LOGS, "\n"), prompt = Prompt(), print = true },
+				})
+				break
+			end
+		end
+
+		if response == nil then
+			-- there was no output from the Boot Loader eval, so we shouldn't print it
+			response = ao.result({ Output = { data = "", prompt = Prompt() } })
+		end
+
+		HANDLER_PRINT_LOGS = {} -- clear logs
+		return response
+	else
+		local response =
+			ao.result({ Output = { data = table.concat(HANDLER_PRINT_LOGS, "\n"), prompt = Prompt(), print = true } })
+		HANDLER_PRINT_LOGS = {} -- clear logs
+		return response
+	end
 end
 
 return process

--- a/process/test/state.test.js
+++ b/process/test/state.test.js
@@ -1,65 +1,96 @@
-import { test } from 'node:test'
-import * as assert from 'node:assert'
-import AoLoader from '@permaweb/ao-loader'
-import fs from 'fs'
+import { test, describe } from "node:test";
+import * as assert from "node:assert";
+import AoLoader from "@permaweb/ao-loader";
+import fs from "fs";
 
-const wasm = fs.readFileSync('./process.wasm')
-const options = { format: "wasm64-unknown-emscripten-draft_2024_02_15" }
+const wasm = fs.readFileSync("./process.wasm");
+const options = { format: "wasm64-unknown-emscripten-draft_2024_02_15" };
 
-test('check state properties for aos', async () => {
-  const handle = await AoLoader(wasm, options)
-  const env = {
-    Process: {
-      Id: 'AOS',
-      Owner: 'FOOBAR',
-      Tags: [
-        { name: 'Name', value: 'Thomas' }
-      ]
-    }
-  }
-  const msg = {
-    Target: 'AOS',
-    From: 'FOOBAR',
-    Owner: 'FOOBAR',
-    From: 'FOOBAR',
-    ['Block-Height']: "1000",
-    Id: "1234xyxfoo",
-    Module: "WOOPAWOOPA",
-    Tags: [
-      { name: 'Action', value: 'Eval' }
-    ],
-    Data: 'print("name: " .. Name .. ", owner: " .. Owner)'
-  }
-  const result = await handle(null, msg, env)
+describe("state", async () => {
+  test("check state properties for aos", async () => {
+    const handle = await AoLoader(wasm, options);
+    const env = {
+      Process: {
+        Id: "AOS",
+        Owner: "FOOBAR",
+        Tags: [{ name: "Name", value: "Thomas" }],
+      },
+    };
+    const msg = {
+      Target: "AOS",
+      From: "FOOBAR",
+      Owner: "FOOBAR",
+      From: "FOOBAR",
+      ["Block-Height"]: "1000",
+      Id: "1234xyxfoo",
+      Module: "WOOPAWOOPA",
+      Tags: [{ name: "Action", value: "Eval" }],
+      Data: 'print("name: " .. Name .. ", owner: " .. Owner)',
+    };
+    const result = await handle(null, msg, env);
 
-  assert.equal(result.Output?.data, 'name: Thomas, owner: FOOBAR')
-  assert.ok(true)
-})
+    assert.equal(result.Output?.data, "name: Thomas, owner: FOOBAR");
+    assert.ok(true);
+  });
 
-test('test authorities', async () => {
-  const handle = await AoLoader(wasm, options)
-  const env = {
-    Process: {
-      Id: 'AOS',
-      Owner: 'FOOBAR',
-      Tags: [
-        { name: 'Name', value: 'Thomas' },
-        { name: 'Authority', value: 'BOOP' }
-      ]
-    }
-  }
-  const msg = {
-    Target: 'AOS',
-    Owner: 'BEEP',
-    From: 'BAM',
-    ['Block-Height']: "1000",
-    Id: "1234xyxfoo",
-    Module: "WOOPAWOOPA",
-    Tags: [
-      { name: 'Action', value: 'Eval' }
-    ],
-    Data: '1 + 1'
-  }
-  const result = await handle(null, msg, env)
-  assert.ok(result.Output.data.includes('Message is not trusted! From: BAM - Owner: BEEP'))
-})
+  test("test authorities", async () => {
+    const handle = await AoLoader(wasm, options);
+    const env = {
+      Process: {
+        Id: "AOS",
+        Owner: "FOOBAR",
+        Tags: [
+          { name: "Name", value: "Thomas" },
+          { name: "Authority", value: "BOOP" },
+        ],
+      },
+    };
+    const msg = {
+      Target: "AOS",
+      Owner: "BEEP",
+      From: "BAM",
+      ["Block-Height"]: "1000",
+      Id: "1234xyxfoo",
+      Module: "WOOPAWOOPA",
+      Tags: [{ name: "Action", value: "Eval" }],
+      Data: "1 + 1",
+    };
+    const result = await handle(null, msg, env);
+    assert.ok(
+      result.Output.data.includes(
+        "Message is not trusted! From: BAM - Owner: BEEP",
+      ),
+    );
+  });
+
+  test("test program state", async () => {
+    const antLua = fs.readFileSync("./aos-bundled.lua", "utf8");
+    const handle = await AoLoader(wasm, options);
+    const env = {
+      Process: {
+        Id: "AOS",
+        Owner: "FOOBAR",
+        Tags: [
+          { name: "Name", value: "Thomas" },
+          { name: "Authority", value: "BOOP" },
+        ],
+      },
+    };
+    const msg = {
+      Target: "AOS",
+      Owner: "FOOBAR",
+      From: "FOOBAR",
+      ["Block-Height"]: "1000",
+      Id: "1234xyxfoo",
+      Module: "WOOPAWOOPA",
+      Tags: [{ name: "Action", value: "Program-State" }],
+    };
+    const antResult = await handle(null, {...msg,
+    Data: antLua,
+    Tags: [{name: "Action", value: "Eval"}]
+    }, env);
+    const result = await handle(antResult.Memory, msg, env);
+    console.dir(JSON.parse(result.Messages[0]?.Data), { depth: null });
+    fs.writeFileSync("./ant-state.json", JSON.stringify(JSON.parse(result.Messages[0]?.Data), null, 2));
+  });
+});

--- a/process/utils.lua
+++ b/process/utils.lua
@@ -1,261 +1,384 @@
 local utils = { _version = "0.0.5" }
 
 function utils.matchesPattern(pattern, value, msg)
-  -- If the key is not in the message, then it does not match
-  if(not pattern) then
-    return false
-  end
-  -- if the patternMatchSpec is a wildcard, then it always matches
-  if pattern == '_' then
-    return true
-  end
-  -- if the patternMatchSpec is a function, then it is executed on the tag value
-  if type(pattern) == "function" then
-    if pattern(value, msg) then
-      return true
-    else
-      return false
-    end
-  end
-  
-  -- if the patternMatchSpec is a string, check it for special symbols (less `-` alone)
-  -- and exact string match mode
-  if (type(pattern) == 'string') then
-    if string.match(pattern, "[%^%$%(%)%%%.%[%]%*%+%?]") then
-      if string.match(value, pattern) then
-        return true
-      end
-    else
-      if value == pattern then
-        return true
-      end
-    end
-  end
+	-- If the key is not in the message, then it does not match
+	if not pattern then
+		return false
+	end
+	-- if the patternMatchSpec is a wildcard, then it always matches
+	if pattern == "_" then
+		return true
+	end
+	-- if the patternMatchSpec is a function, then it is executed on the tag value
+	if type(pattern) == "function" then
+		if pattern(value, msg) then
+			return true
+		else
+			return false
+		end
+	end
 
-  -- if the pattern is a table, recursively check if any of its sub-patterns match
-  if type(pattern) == 'table' then
-    for _, subPattern in pairs(pattern) do
-      if utils.matchesPattern(subPattern, value, msg) then
-        return true
-      end
-    end
-  end
+	-- if the patternMatchSpec is a string, check it for special symbols (less `-` alone)
+	-- and exact string match mode
+	if type(pattern) == "string" then
+		if string.match(pattern, "[%^%$%(%)%%%.%[%]%*%+%?]") then
+			if string.match(value, pattern) then
+				return true
+			end
+		else
+			if value == pattern then
+				return true
+			end
+		end
+	end
 
-  return false
+	-- if the pattern is a table, recursively check if any of its sub-patterns match
+	if type(pattern) == "table" then
+		for _, subPattern in pairs(pattern) do
+			if utils.matchesPattern(subPattern, value, msg) then
+				return true
+			end
+		end
+	end
+
+	return false
 end
 
 function utils.matchesSpec(msg, spec)
-  if type(spec) == 'function' then
-    return spec(msg)
-  -- If the spec is a table, step through every key/value pair in the pattern and check if the msg matches
-  -- Supported pattern types:
-  --   - Exact string match
-  --   - Lua gmatch string
-  --   - '_' (wildcard: Message has tag, but can be any value)
-  --   - Function execution on the tag, optionally using the msg as the second argument
-  --   - Table of patterns, where ANY of the sub-patterns matching the tag will result in a match
-  end
-  if type(spec) == 'table' then
-    for key, pattern in pairs(spec) do
-      if not msg[key] then
-        return false
-      end
-      if not utils.matchesPattern(pattern, msg[key], msg) then
-        return false
-      end
-    end
-    return true
-  end
-  if type(spec) == 'string' and msg.Action and msg.Action == spec then
-    return true
-  end
-  return false
+	if type(spec) == "function" then
+		return spec(msg)
+		-- If the spec is a table, step through every key/value pair in the pattern and check if the msg matches
+		-- Supported pattern types:
+		--   - Exact string match
+		--   - Lua gmatch string
+		--   - '_' (wildcard: Message has tag, but can be any value)
+		--   - Function execution on the tag, optionally using the msg as the second argument
+		--   - Table of patterns, where ANY of the sub-patterns matching the tag will result in a match
+	end
+	if type(spec) == "table" then
+		for key, pattern in pairs(spec) do
+			if not msg[key] then
+				return false
+			end
+			if not utils.matchesPattern(pattern, msg[key], msg) then
+				return false
+			end
+		end
+		return true
+	end
+	if type(spec) == "string" and msg.Action and msg.Action == spec then
+		return true
+	end
+	return false
 end
 
 local function isArray(table)
-  if type(table) == "table" then
-      local maxIndex = 0
-      for k, v in pairs(table) do
-          if type(k) ~= "number" or k < 1 or math.floor(k) ~= k then
-              return false -- If there's a non-integer key, it's not an array
-          end
-          maxIndex = math.max(maxIndex, k)
-      end
-      -- If the highest numeric index is equal to the number of elements, it's an array
-      return maxIndex == #table
-  end
-  return false
+	if type(table) == "table" then
+		local maxIndex = 0
+		for k, v in pairs(table) do
+			if type(k) ~= "number" or k < 1 or math.floor(k) ~= k then
+				return false -- If there's a non-integer key, it's not an array
+			end
+			maxIndex = math.max(maxIndex, k)
+		end
+		-- If the highest numeric index is equal to the number of elements, it's an array
+		return maxIndex == #table
+	end
+	return false
 end
 
 -- @param {function} fn
 -- @param {number} arity
-utils.curry = function (fn, arity)
-  assert(type(fn) == "function", "function is required as first argument")
-  arity = arity or debug.getinfo(fn, "u").nparams
-  if arity < 2 then return fn end
+utils.curry = function(fn, arity)
+	assert(type(fn) == "function", "function is required as first argument")
+	arity = arity or debug.getinfo(fn, "u").nparams
+	if arity < 2 then
+		return fn
+	end
 
-  return function (...)
-    local args = {...}
+	return function(...)
+		local args = { ... }
 
-    if #args >= arity then
-      return fn(table.unpack(args))
-    else
-      return utils.curry(function (...)
-        return fn(table.unpack(args),  ...)
-      end, arity - #args)
-    end
-  end
+		if #args >= arity then
+			return fn(table.unpack(args))
+		else
+			return utils.curry(function(...)
+				return fn(table.unpack(args), ...)
+			end, arity - #args)
+		end
+	end
 end
 
 --- Concat two Array Tables.
 -- @param {table<Array>} a
 -- @param {table<Array>} b
-utils.concat = utils.curry(function (a, b)
-  assert(type(a) == "table", "first argument should be a table that is an array")
-  assert(type(b) == "table", "second argument should be a table that is an array")
-  assert(isArray(a), "first argument should be a table")
-  assert(isArray(b), "second argument should be a table")
+utils.concat = utils.curry(function(a, b)
+	assert(type(a) == "table", "first argument should be a table that is an array")
+	assert(type(b) == "table", "second argument should be a table that is an array")
+	assert(isArray(a), "first argument should be a table")
+	assert(isArray(b), "second argument should be a table")
 
-  local result = {}
-  for i = 1, #a do
-      result[#result + 1] = a[i]
-  end
-  for i = 1, #b do
-      result[#result + 1] = b[i]
-  end
-  return result
-  --return table.concat(a,b)
+	local result = {}
+	for i = 1, #a do
+		result[#result + 1] = a[i]
+	end
+	for i = 1, #b do
+		result[#result + 1] = b[i]
+	end
+	return result
+	--return table.concat(a,b)
 end, 2)
 
 --- reduce applies a function to a table
 -- @param {function} fn
 -- @param {any} initial
 -- @param {table<Array>} t
-utils.reduce = utils.curry(function (fn, initial, t)
-  assert(type(fn) == "function", "first argument should be a function that accepts (result, value, key)")
-  assert(type(t) == "table" and isArray(t), "third argument should be a table that is an array")
-  local result = initial
-  for k, v in pairs(t) do
-    if result == nil then
-      result = v
-    else
-      result = fn(result, v, k)
-    end
-  end
-  return result
+utils.reduce = utils.curry(function(fn, initial, t)
+	assert(type(fn) == "function", "first argument should be a function that accepts (result, value, key)")
+	assert(type(t) == "table" and isArray(t), "third argument should be a table that is an array")
+	local result = initial
+	for k, v in pairs(t) do
+		if result == nil then
+			result = v
+		else
+			result = fn(result, v, k)
+		end
+	end
+	return result
 end, 3)
 
 -- @param {function} fn
 -- @param {table<Array>} data
-utils.map = utils.curry(function (fn, data)
-  assert(type(fn) == "function", "first argument should be a unary function")
-  assert(type(data) == "table" and isArray(data), "second argument should be an Array")
+utils.map = utils.curry(function(fn, data)
+	assert(type(fn) == "function", "first argument should be a unary function")
+	assert(type(data) == "table" and isArray(data), "second argument should be an Array")
 
-  local function map (result, v, k)
-    result[k] = fn(v, k)
-    return result
-  end
+	local function map(result, v, k)
+		result[k] = fn(v, k)
+		return result
+	end
 
-  return utils.reduce(map, {}, data)
+	return utils.reduce(map, {}, data)
 end, 2)
 
 -- @param {function} fn
 -- @param {table<Array>} data
-utils.filter = utils.curry(function (fn, data)
-  assert(type(fn) == "function", "first argument should be a unary function")
-  assert(type(data) == "table" and isArray(data), "second argument should be an Array")
+utils.filter = utils.curry(function(fn, data)
+	assert(type(fn) == "function", "first argument should be a unary function")
+	assert(type(data) == "table" and isArray(data), "second argument should be an Array")
 
-  local function filter (result, v, _k)
-    if fn(v) then
-      table.insert(result, v)
-    end
-    return result
-  end
+	local function filter(result, v, _k)
+		if fn(v) then
+			table.insert(result, v)
+		end
+		return result
+	end
 
-  return utils.reduce(filter,{}, data)
+	return utils.reduce(filter, {}, data)
 end, 2)
 
 -- @param {function} fn
 -- @param {table<Array>} t
-utils.find = utils.curry(function (fn, t)
-  assert(type(fn) == "function", "first argument should be a unary function")
-  assert(type(t) == "table", "second argument should be a table that is an array")
-  for _, v in pairs(t) do
-    if fn(v) then
-      return v
-    end
-  end
+utils.find = utils.curry(function(fn, t)
+	assert(type(fn) == "function", "first argument should be a unary function")
+	assert(type(t) == "table", "second argument should be a table that is an array")
+	for _, v in pairs(t) do
+		if fn(v) then
+			return v
+		end
+	end
 end, 2)
 
 -- @param {string} propName
--- @param {string} value 
+-- @param {string} value
 -- @param {table} object
-utils.propEq = utils.curry(function (propName, value, object)
-  assert(type(propName) == "string", "first argument should be a string")
-  -- assert(type(value) == "string", "second argument should be a string")
-  assert(type(object) == "table", "third argument should be a table<object>")
-  
-  return object[propName] == value
+utils.propEq = utils.curry(function(propName, value, object)
+	assert(type(propName) == "string", "first argument should be a string")
+	-- assert(type(value) == "string", "second argument should be a string")
+	assert(type(object) == "table", "third argument should be a table<object>")
+
+	return object[propName] == value
 end, 3)
 
 -- @param {table<Array>} data
-utils.reverse = function (data)
-  assert(type(data) == "table", "argument needs to be a table that is an array")
-  return utils.reduce(
-    function (result, v, i)
-      result[#data - i + 1] = v
-      return result
-    end,
-    {},
-    data
-  )
+utils.reverse = function(data)
+	assert(type(data) == "table", "argument needs to be a table that is an array")
+	return utils.reduce(function(result, v, i)
+		result[#data - i + 1] = v
+		return result
+	end, {}, data)
 end
 
--- @param {function} ... 
-utils.compose = utils.curry(function (...)
-  local mutations = utils.reverse({...})
+-- @param {function} ...
+utils.compose = utils.curry(function(...)
+	local mutations = utils.reverse({ ... })
 
-  return function (v)
-    local result = v
-    for _, fn in pairs(mutations) do
-      assert(type(fn) == "function", "each argument needs to be a function")
-      result = fn(result)
-    end
-    return result
-  end
+	return function(v)
+		local result = v
+		for _, fn in pairs(mutations) do
+			assert(type(fn) == "function", "each argument needs to be a function")
+			result = fn(result)
+		end
+		return result
+	end
 end, 2)
 
 -- @param {string} propName
 -- @param {table} object
-utils.prop = utils.curry(function (propName, object) 
-  return object[propName]
+utils.prop = utils.curry(function(propName, object)
+	return object[propName]
 end, 2)
 
 -- @param {any} val
 -- @param {table<Array>} t
-utils.includes = utils.curry(function (val, t)
-  assert(type(t) == "table", "argument needs to be a table")
-  return utils.find(function (v) return v == val end, t) ~= nil
+utils.includes = utils.curry(function(val, t)
+	assert(type(t) == "table", "argument needs to be a table")
+	return utils.find(function(v)
+		return v == val
+	end, t) ~= nil
 end, 2)
 
 -- @param {table} t
-utils.keys = function (t)
-  assert(type(t) == "table", "argument needs to be a table")
-  local keys = {}
-  for key in pairs(t) do
-    table.insert(keys, key)
-  end
-  return keys
+utils.keys = function(t)
+	assert(type(t) == "table", "argument needs to be a table")
+	local keys = {}
+	for key in pairs(t) do
+		table.insert(keys, key)
+	end
+	return keys
 end
 
 -- @param {table} t
-utils.values = function (t)
-  assert(type(t) == "table", "argument needs to be a table")
-  local values = {}
-  for _, value in pairs(t) do
-    table.insert(values, value)
-  end
-  return values
+utils.values = function(t)
+	assert(type(t) == "table", "argument needs to be a table")
+	local values = {}
+	for _, value in pairs(t) do
+		table.insert(values, value)
+	end
+	return values
 end
+
+utils.parseFunctionCode = function(fn)
+	assert(type(fn) == "function", "argument needs to be a function")
+	-- Get debug information about the function
+	local info = debug.getinfo(fn)
+
+	if not info then
+		return
+	end
+
+	local sourceString = info.source
+	local startLine = info.linedefined
+	local endLine = info.lastlinedefined
+
+	-- Split the source string into lines
+	local lines = {}
+	for line in sourceString:gmatch("([^\r\n]*)\r?\n?") do
+		table.insert(lines, line)
+	end
+
+	-- Extract the function code
+	local code = ""
+  if #lines < endLine - startLine then
+    -- this means the source is not available, just the short source
+    code = sourceString
+  else
+    for i = startLine, endLine do
+      if lines[i] then
+        code = code .. lines[i] .. "\n"
+      end
+    end
+  end
+
+
+	return code
+end
+
+utils.parseCoroutine = function(co)
+	assert(type(co) == "thread", "argument needs to be a coroutine")
+	local status = coroutine.status(co)
+	local stackTrace = debug.traceback(co)
+
+	-- Retrieve function details from the coroutine (if available)
+	local coFunctionInfo = debug.getinfo(co, 0)
+	local functionSourceOk, functionSource = pcall(utils.parseFunctionCode, coFunctionInfo.func)
+
+	return {
+		status = status,
+		stackTrace = stackTrace,
+		functionSource = functionSourceOk and functionSource or "Failed to retrieve function source",
+	}
+end
+
+-- Central parsing function for all types
+utils.parseValue = function(value, visited)
+    visited = visited or {}
+
+    if type(value) == "function" then
+        local success, funcCode = pcall(utils.parseFunctionCode, value)
+        return success and funcCode or "Failed to parse function"
+    elseif type(value) == "thread" then
+        return utils.parseCoroutine(value)
+    elseif type(value) == "table" then
+        -- Avoid circular references
+        if visited[value] then
+            return "<circular reference>"
+        end
+        visited[value] = true
+        local result = {}
+        for k, v in pairs(value) do
+            -- Handle non-string keys as in previous example
+            local key
+            if type(k) == "string" then
+                key = k
+            else
+                key = tostring(k)
+            end
+            result[key] = utils.parseValue(v, visited)
+        end
+        return result
+    elseif type(value) == "userdata" then
+        return "<userdata>"  -- Userdata cannot be serialized, handle as string
+    elseif type(value) == "number" then
+        -- Check for 'inf', '-inf', or 'nan' and handle them
+        if value == math.huge then
+            return "inf"  -- Convert 'inf' to a string
+        elseif value == -math.huge then
+            return "-inf"  -- Convert '-inf' to a string
+        elseif value ~= value then  -- Check for 'nan'
+            return "NaN"  -- Convert 'NaN' to a string
+        else
+            return value  -- Regular numbers are fine for JSON
+        end
+    elseif type(value) == "boolean" or type(value) == "string" then
+        return value  -- Safe for serialization
+    else
+        return "<unsupported type>"  -- Any other unsupported types
+    end
+end
+
+
+utils.getProgramState = function()
+	local packages = {}
+	local visitedTables = {}
+
+	-- Parse loaded packages
+	for packageName, loadedPackage in pairs(package.loaded) do
+		if packageName ~= "package" and packageName ~= "_G" then
+      packages[packageName] = utils.parseValue(loadedPackage, visitedTables)
+      end
+		-- This handles packages regardless of whether they are functions, tables, etc.
+		-- Circular references are also managed automatically.
+		end
+
+	-- Parse global variables
+	local globals = utils.parseValue(_G, {})
+
+	return {
+		packages = packages,
+		globals = globals,
+	}
+end
+
 
 return utils


### PR DESCRIPTION
The intent with this PR is to enable users and applications like aos-web and betteridea to perform analysis on a live process to view the actual currently running code and variables. It analyzes the lua globals via the`_G` global, and the packages loaded from the lua `package` system.

The achieve this, we use the `.getinfo` utiil from the `debug` introspective stdlib.

Actually being able to retrieve the function source required modifying how the `load` method is used in the `eval` handler. Rather than the function name of "aos" being passed in, we pass the entire expression. This can then be used to traverse the lines where the function is defined in the source file.

A current limitation of this is being able to show modules that are precompiled - for us to have context of the string where the function is defined (those loaded with the `eval` handler) they must have been loaded into the current program state.

Still need to do some further experimentation in conjunction with the AO dev-cli, in particular here: https://github.com/permaweb/ao/blob/e2088442a399e871db552fb5031ae73bbf36c9b9/dev-cli/container/src/core/main.lua#L15

Where I suspect its just a matter of updating those load uses as well.

check out the ant-state.json for example output for program state :)

Still needs some refining, in particular the Handlers code retrieval, which I hope will become more visible with dev-cli updates.

Hopefully this will grant greater debugging utilities and program versioning.

