### PR TITLE
fix(aos): fix error line number in aos

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -532,6 +532,8 @@ async function doEvaluate(line, id, jwk, spinner, rl, loadedModules, dryRunMode)
   if (result?.Error || result?.error) {
     const error = parseError(result.Error || result.error)
     if (error) {
+      // When loading, '\n\n' is prepended to the file. This creates a 2 line offset. Fix it here.
+      error.lineNumber -= 2
       // get what file the error comes from,
       // if the line was loaded
       const errorOrigin = getErrorOrigin(loadedModules, error.lineNumber)

--- a/src/services/errors.js
+++ b/src/services/errors.js
@@ -69,13 +69,12 @@ export function getErrorOrigin(loadedModules, lineNumber) {
   let currentLine = 0
 
   for (let i = 0; i < loadedModules.length; i++) {
-    // get module line count
-    const lineCount = (loadedModules[i].content.match(/\r?\n/g)?.length || 0) + 1
-
+    // get module line count, add 2 for '\n\n' offset
+    const lineCount = (loadedModules[i].content.match(/\r?\n/g)?.length || 0) + 1 + 2
     if (currentLine + lineCount >= lineNumber) {
       return {
         file: loadedModules[i].path,
-        line: lineNumber - currentLine - i * 2
+        line: lineNumber - currentLine - (i + 1) * 2
       }
     }
 
@@ -95,15 +94,25 @@ export function outputError(line, error, origin) {
   const lineNumber = origin?.line || error.lineNumber
   const lineNumberPlaceholder = ' '.repeat(lineNumber.toString().length)
 
-  console.log(
-    '\n' +
-    chalk.bold(error.errorMessage) +
-    '\n' +
-    (origin ? chalk.dim(`  in ${origin.file}\n`) : "") +
-    chalk.blue(` ${lineNumberPlaceholder} |\n ${lineNumber} |    `) +
-    line.split('\n')[error.lineNumber - 1] +
-    '\n' +
-    chalk.blue(` ${lineNumberPlaceholder} |\n`) +
-    chalk.dim('This error occurred while aos was evaluating the submitted code.')
-  )
+  if (origin) {
+    console.log(
+      '\n' +
+      chalk.bold(error.errorMessage) +
+      '\n' +
+      (origin ? chalk.dim(`  in ${origin.file}\n`) : "") +
+      chalk.blue(` ${lineNumberPlaceholder} |\n ${lineNumber} |    `) +
+      // Add 2 lines back as the line does not includes the '\n\n' offset
+      line.split('\n')[error.lineNumber - 1 + 2] +
+      '\n' +
+      chalk.blue(` ${lineNumberPlaceholder} |\n`) +
+      chalk.dim('This error occurred while aos was evaluating the submitted code.')
+    )
+  } else {
+    console.log(
+      '\n' +
+      chalk.bold(`Error on line ${lineNumber}: ${error.errorMessage}`) +
+      '\n' +
+      chalk.dim('This error occurred while aos was evaluating the submitted code.')
+    )
+  }
 }


### PR DESCRIPTION
Closes #330 

Offsets the 2 line addition of '\n\n' to all loaded modules. 