### PR TITLE
fix(weavedrive): use fetch in lieu of arweave js client to make graphql calls. Fix graphql operations.

### DIFF
--- a/.github/workflows/weavedrive.yml
+++ b/.github/workflows/weavedrive.yml
@@ -1,0 +1,109 @@
+name: 🧶💾 Build & Release WeaveDrive
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "extensions/weavedrive/**"
+  push:
+    branches:
+      - main
+    paths:
+      - "extensions/weavedrive/**"
+
+  # Perform a release using a workflow dispatch
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "semver version to bump to"
+        required: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test:
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v4
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: 📥 Download deps
+        working-directory: extensions/weavedrive
+        run: |
+          npm i
+
+      - name: ⚡ Run Tests
+        working-directory: extensions/weavedrive
+        run: |
+          npm test
+        env:
+          CI: true
+
+  release:
+    # Releases are performed via a workflow dispatch
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: release
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: "https://registry.npmjs.org"
+
+      - name: 👀 Env
+        run: |
+          echo "Event name: ${{ github.event_name }}"
+          echo "Git ref:    ${{ github.ref }}"
+          echo "GH actor:   ${{ github.actor }}"
+          echo "SHA:        ${{ github.sha }}"
+          VER=`node --version`; echo "Node ver:   $VER"
+          VER=`npm --version`; echo "npm ver:    $VER"
+
+      - name: 🤓 Set Git User
+        run: |
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: ✊ Bump
+        id: bump
+        uses: hyper63/hyper-ci-bump@v2.1.0
+        with:
+          bump-to: ${{ github.event.inputs.version }}
+          package: weavedrive
+  
+      - name: ⬆️ Push
+        run: |
+          git push
+          git push --tags
+
+      - name: 📥 Download deps
+        working-directory: extensions/weavedrive
+        run: |
+          npm i
+
+      # Build aos
+      - name: 🦠 Publish to NPM
+        working-directory: extensions/weavedrive
+        run: |
+          npm run build
+          npm publish --access=public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/extensions/weavedrive/package-lock.json
+++ b/extensions/weavedrive/package-lock.json
@@ -12,7 +12,7 @@
         "arweave": "^1.15.5"
       },
       "devDependencies": {
-        "@permaweb/ao-loader": "^0.0.39",
+        "@permaweb/ao-loader": "^0.0.43",
         "esbuild": "^0.24.0"
       }
     },
@@ -425,9 +425,9 @@
       }
     },
     "node_modules/@permaweb/ao-loader": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@permaweb/ao-loader/-/ao-loader-0.0.39.tgz",
-      "integrity": "sha512-VPY26/6/RDfVQ9jIhEGrO55FDB9RWjHn5YUkfltGB6fXIScPdPifsSbtTMWhJAjO+ZcamTPkSk6F02hw7VGARg==",
+      "version": "0.0.43",
+      "resolved": "https://registry.npmjs.org/@permaweb/ao-loader/-/ao-loader-0.0.43.tgz",
+      "integrity": "sha512-xPYzyKSCqtL0U8oUcCrW+uPpm7IcMncM5IPVGCGKljxA3IQA/HI8S5XA6tcZUaDRCl8VSVsJzqOgkdzy1JGi5w==",
       "dev": true,
       "dependencies": {
         "@permaweb/wasm-metering": "^0.2.2"

--- a/extensions/weavedrive/package.json
+++ b/extensions/weavedrive/package.json
@@ -14,7 +14,7 @@
     "arweave": "^1.15.5"
   },
   "devDependencies": {
-    "@permaweb/ao-loader": "^0.0.39",
+    "@permaweb/ao-loader": "^0.0.43",
     "esbuild": "^0.24.0"
   }
 }

--- a/extensions/weavedrive/src/index.js
+++ b/extensions/weavedrive/src/index.js
@@ -564,9 +564,10 @@ module.exports = function weaveDrive(mod, FS) {
       return values.pop()
     },
 
-    async queryHasResult(query) {
-      const results = await mod.arweave.api.post('/graphql', query);
-      const json = JSON.parse(results)
+    async queryHasResult(query, variables) {
+      const json = await this.gqlQuery(query, variables)
+        .then((res) => res.json())
+
       return json.data.transactions.edges.length > 0
     },
 

--- a/extensions/weavedrive/src/index.js
+++ b/extensions/weavedrive/src/index.js
@@ -441,7 +441,7 @@ module.exports = function weaveDrive(mod, FS) {
       const blockHeight = mod.blockHeight
       const moduleExtensions = this.getTagValues("Extension", mod.module.tags)
       const moduleHasWeaveDrive = moduleExtensions.includes("WeaveDrive")
-      const processExtensions = this.getTagValues("Extension", mod.module.tags)
+      const processExtensions = this.getTagValues("Extension", mod.spawn.tags)
       const processHasWeaveDrive = moduleHasWeaveDrive || processExtensions.includes("WeaveDrive")
 
       if (!processHasWeaveDrive) {
@@ -471,7 +471,7 @@ module.exports = function weaveDrive(mod, FS) {
         [
           this.getTagValue('Scheduler', mod.spawn.tags),
           ...this.getTagValues("Attestor", mod.spawn.tags)
-        ]
+        ].filter(t => !!t)
       )
 
       // Init a set of GraphQL queries to run in order to find a valid attestation
@@ -510,7 +510,7 @@ module.exports = function weaveDrive(mod, FS) {
               owners: ${attestors},
               block: {min: 0, max: ${blockHeight}},
               tags: [
-                { name: "Data-Protocol", values: ["WeaveDrive"],
+                { name: "Data-Protocol", values: ["WeaveDrive"] },
                 { name: "Type", values: ["Available"]},
                 { name: "ID", values: ["${ID}"]}
               ]
@@ -568,7 +568,7 @@ module.exports = function weaveDrive(mod, FS) {
       const json = await this.gqlQuery(query, variables)
         .then((res) => res.json())
 
-      return json.data.transactions.edges.length > 0
+      return !!json?.data?.transactions?.edges?.length
     },
 
     async gqlExists() {


### PR DESCRIPTION
This PR fixes an issue in WeaveDrive, where a non-existent arweavejs client was being used to call an arweave gateway. The rest of the impl uses an internal api built around `fetch`, so I simply swapped the use arweavejs to using that api as well.

This PR also fixes malformed graphql queries that would fail, if made to an arweave gateway.

This PR also fixes a bug where module tags were being checked instead of process tags, when determining the `Availablity-Type`

Finally, I added tests to assert the correctness of loading txs in `Availability-Types` `Assignments` and `Individual`

> the code changes are small -- the largest diff is the tests, which were previously unimplemented.