### PR TITLE
fix(services/version): prevent checkForUpdate() 5xx response codes from stopping connection

### DIFF
--- a/src/services/version.js
+++ b/src/services/version.js
@@ -28,7 +28,19 @@ export const checkForUpdate = () => new Promise(async (resolve, reject) => {
     const res = await fetch(UPDATE_URL)
     const data = []
     const extract = tar.extract()
-    if (res.status === 404) { return resolve({ available: false }) }
+
+    if (res.status === 404) {
+      return resolve({ available: false })
+    }
+
+    if (res.status >= 500) {
+      if (process.env.DEBUG) {
+        console.log(chalk.yellow(`Warning: The update server (${UPDATE_URL}) responded with a ${res.status} status code\n`))
+      }
+
+      return resolve({ available: false })
+    }
+
     Readable.fromWeb(res.body).pipe(createGunzip()).pipe(extract)
 
     extract.on('entry', (header, stream, next) => {

--- a/test/services/version.test.js
+++ b/test/services/version.test.js
@@ -1,0 +1,40 @@
+import { mock, test } from 'node:test'
+import * as assert from 'node:assert'
+import { checkForUpdate } from '../../src/services/version.js'
+import { STATUS_CODES } from 'node:http'
+
+test('checkForUpdate() handles 404 response', async (context) => {
+  fetch = context.mock.fn(fetch, () => {
+    return {
+      status: 404
+    }
+  })
+
+  const actual = await checkForUpdate()
+  assert.deepEqual(actual, { available: false })
+})
+
+test('checkForUpdate() handles 5xx responses', async (context) => {
+  const statusCodes = Object
+    .keys(STATUS_CODES)
+    .filter((statusCode) => +statusCode >= 500 )
+    .map((statusCode) => +statusCode)
+
+  const statusContexts = statusCodes.map((statusCode) => {
+    return {
+      status: statusCode,
+      expected: { available: false },
+    }
+  });
+
+  for (const statusContext of statusContexts) {
+    fetch = context.mock.fn(fetch, () => {
+      return {
+        status: statusContext.status,
+      }
+    })
+  
+    const actual = await checkForUpdate()
+    assert.deepEqual(actual, statusContext.expected)
+  }
+})


### PR DESCRIPTION
I was receiving this error earlier today and couldn't connect to my process:

<img width="499" alt="Screenshot 2024-10-30 at 11 23 55" src="https://github.com/user-attachments/assets/37702793-f3ee-4d3b-a547-f5a21a1c6dce">

I found the issue was around the response code returned from fetching from `UPDATE_URL` (value is `https://get_ao.g8way.io`) for an update. The response code was `502`.

Although this PR doesn't address every edge case, it addresses the one I experienced earlier today. This PR introduces the following:

- Returns `{ available: false }` if fetching from update URL returns a 5xx status code
- Adds tests to ensure 404 and 5xx status codes return `{ available: false }`
- When `process.env.DEBUG` is truthy, a warning message will be shown for fetches that result in 5xx status codes. For example:
    <img width="532" alt="Screenshot 2024-10-30 at 11 30 40" src="https://github.com/user-attachments/assets/0e82600a-549c-46fa-9745-3dd15e2589f0">
