### PR TITLE
Add Action Tag to broadcasted messages in Chatroom Blueprint

### DIFF
--- a/blueprints/chatroom.lua
+++ b/blueprints/chatroom.lua
@@ -47,7 +47,7 @@ Handlers.add(
     local haveSentRecords = {}
     for _, recipient in ipairs(Members) do
       if not haveSentRecords[recipient] then
-        ao.send({Target = recipient, Data = msg.Data})
+        ao.send({Target = recipient, Action = "Broadcast" Data = msg.Data})
         haveSentRecords[recipient] = true
       end
     end

--- a/blueprints/chatroom.lua
+++ b/blueprints/chatroom.lua
@@ -47,7 +47,7 @@ Handlers.add(
     local haveSentRecords = {}
     for _, recipient in ipairs(Members) do
       if not haveSentRecords[recipient] then
-        ao.send({Target = recipient, Action = "Broadcast" Data = msg.Data})
+        ao.send({Target = recipient, Action = "Broadcast-Notice", Data = msg.Data})
         haveSentRecords[recipient] = true
       end
     end


### PR DESCRIPTION
Adding an Action Tag to the Broadcasted message could help filter chatroom message from all the other incoming messages. This filtered output could be stored in a separate variable or help in creating a frontend listener just for chats while ensuring the chatroom blueprint does not need a separate process