### PR TITLE
fix(weavedrive): store headers as utf8 encoded

### DIFF
--- a/extensions/weavedrive/src/index.js
+++ b/extensions/weavedrive/src/index.js
@@ -105,7 +105,7 @@ module.exports = function weaveDrive(mod, FS) {
 
       var bytesLength = result.length;
 
-      var node = FS.createDataFile('/', 'block/' + id, result, true, false);
+      var node = FS.createDataFile('/', 'block/' + id, Buffer.from(result, 'utf-8'), true, false);
 
       var stream = FS.open('/block/' + id, 'r');
       return stream;
@@ -135,7 +135,7 @@ module.exports = function weaveDrive(mod, FS) {
         //.then(x => (console.error(x), x))
         .then(x => JSON.stringify(x));
 
-      var node = FS.createDataFile('/', 'tx/' + id, result, true, false);
+      var node = FS.createDataFile('/', 'tx/' + id, Buffer.from(result, 'utf-8'), true, false);
       var stream = FS.open('/tx/' + id, 'r');
       return stream;
     },
@@ -220,7 +220,7 @@ module.exports = function weaveDrive(mod, FS) {
       if (result === 'No results') {
         return result
       }
-      FS.createDataFile('/', 'tx2/' + id, result, true, false);
+      FS.createDataFile('/', 'tx2/' + id, Buffer.from(result, 'utf-8'), true, false);
       var stream = FS.open('/tx2/' + id, 'r');
 
       return stream;

--- a/extensions/weavedrive/test/index.test.js
+++ b/extensions/weavedrive/test/index.test.js
@@ -356,6 +356,24 @@ return result
   assert.equal(data.block.height, 1290333)
 })
 
+test('data item with chinese characters', async () => {
+  const chineseCharacterTx = 'Xg82mcAfQNgJetk_kSKqMkwYDfoMJLGw8fdheU3evWk'
+  const handle = await AoLoader(wasm, options)
+  const result = await handle(memory, {
+    ...Msg,
+      Data: `
+      local data = require('WeaveDrive').getDataItem('${chineseCharacterTx}')
+      local json = require('json')
+      local decoded = json.decode(data)
+      return data
+  `
+  }, { Process, Module })
+  memory = result.Memory
+  const data = JSON.parse(result.Output.data)
+  const description = data.tags.find(tag => tag.name === 'Description')?.value
+  assert.equal(description, "Smartweave是不是要转到AO了？\n本文档介绍原子资产SmartWeave合约的标准接口。原子资产是SmartWeave合约及其在发布到Arweave的同一事务中初始化的数据。SmartWeave合约和数据共享一个交易ID。")
+})
+
 test('read data item tx, no result', async () => {
   const handle = await AoLoader(wasm, options)
   const result = await handle(memory, {


### PR DESCRIPTION
Weavedrive pulling data with Chinese characters is was resulting in special characters: 
```
Desired: 
... { name: 'Description', value: 'Smartweave是不是要转到AO了？本文档介绍原子资产SmartWeave合约的标准接口。原子资产是SmartWeave合约及其在发布到Arweave的同一事务中初始化的数据。SmartWeave合约和数据共享一个交易ID。' } ...
Actual:
... {"name":"Description","value":"Smartweave/�-��pnSmartWeav��pnq�*�ID"} ...
```
If tried to decode using JSON.decode, get the following error:
```
[string ".handlers"]:559: [string "json"]:261: control character in string at line 1 col 2531
```
The issue is in the encoding: When saving to the emscripten file system, the files are not automatically encoded as `utf-8` (the preferred encoding for Chinese characters). Now, we will encode the data manually.