### PR TITLE
fix(aos): fix mismatched version, aos query not working

### DIFF
--- a/process/process.lua
+++ b/process/process.lua
@@ -39,7 +39,7 @@ assignment.init(ao)
 -- @table process
 -- @field _version The version number of the process
 
-local process = { _version = "2.0.3" }
+local process = { _version = "2.0.5" }
 -- The maximum number of messages to store in the inbox
 local maxInboxCount = 10000
 

--- a/src/commands/os.js
+++ b/src/commands/os.js
@@ -10,6 +10,7 @@ import path from 'node:path'
 import os from 'node:os'
 import * as url from 'url'
 import chalk from 'chalk'
+import { getPkg } from '../services/get-pkg.js'
 
 
 let __dirname = url.fileURLToPath(new URL('.', import.meta.url));
@@ -34,7 +35,6 @@ export function update() {
     })
     .concat(patch())
     .concat(patch2())
-    .concat("print([[\nUpdated AOS to version ]] .. require('.process')._version)")
     .join('\n\n')
 
   luaFiles = `
@@ -61,6 +61,15 @@ end
 if not _G.package.loaded['ao'] then
   _G.package.loaded['ao'] = _G.package.loaded['.ao'] 
 end 
+  \n`
+
+  // get the AOS version from the package.json
+  const pkg = getPkg()
+
+  luaFiles = luaFiles + `
+-- update process version to package.json version
+  _G.package.loaded['.process']['_version'] = '${pkg.version}'
+  print([[\nUpdated AOS to version ]] .. '${pkg.version}')
   \n`
 
   return luaFiles


### PR DESCRIPTION
Fixes 2 issues:
1. Running `aos` was resulting in different processes being spawned. This was because owners was set as `owners: [address, argv.address || ""]`, and when address was not set, the empty string in the variables would cause the query to time out. Fixes this with a ternary, as well as adding retries for failed gql queries

2. Version mismatch - Prompt was getting aos version from process.lua, which has not been updated. Updated this value, as well as adding to os.js to update .process.version with package.json (correct) version.