### PR TITLE
Fix `-` breaking loaded projects

### DIFF
--- a/src/services/loading-files.js
+++ b/src/services/loading-files.js
@@ -28,7 +28,7 @@ export function checkLoadArgs() {
  * @returns {[string, Module[]]}
  */
 export function createExecutableFromProject(project) {
-  const getModFnName = (name) => name.replace(/\./g, '_').replace(/^_/, '')
+  const getModFnName = (name) => name.replace(/\.|-/g, '_').replace(/^_/, '')
   /** @type {Module[]} */
   const contents = []
 


### PR DESCRIPTION
When loading multiple files, module names with "-" in them cause syntax errors. "-" is not also replaced with "_".