### PR TITLE
Batch Transfer

### DIFF
--- a/blueprints/token.lua
+++ b/blueprints/token.lua
@@ -80,7 +80,7 @@ Handlers.add('info', Handlers.utils.hasMatchingTag("Action", "Info"), function(m
       Denomination = tostring(Denomination)
     })
   else
-    Send({Target = msg.From, 
+    Send({Target = msg.From,
     Name = Name,
     Ticker = Ticker,
     Logo = Logo,
@@ -129,11 +129,147 @@ end)
    ]]
 --
 Handlers.add('balances', Handlers.utils.hasMatchingTag("Action", "Balances"),
-  function(msg) 
+  function(msg)
     if msg.reply then
       msg.reply({ Data = json.encode(Balances) })
-    else 
-      Send({Target = msg.From, Data = json.encode(Balances) }) 
+    else
+      Send({Target = msg.From, Data = json.encode(Balances) })
+    end
+  end)
+
+   --[[
+     Batch-Transfer
+     Processes multiple transfers atomically from a CSV input
+   ]]
+ --
+Handlers.add('batch-transfer', Handlers.utils.hasMatchingTag("Action", "Batch-Transfer"), function(msg)
+    --[[
+      CSV Parser Implementation
+      ------------------------
+      Simple CSV parser that splits input by newlines and commas
+      to create a 2D table of values.
+    ]]
+    local function parseCSV(csvText)
+      local result = {}
+      -- Split by newlines and process each line
+      for line in csvText:gmatch("[^\r\n]+") do
+        local row = {}
+        -- Split line by commas and add each value to the row
+        for value in line:gmatch("[^,]+") do
+          table.insert(row, value)
+        end
+        table.insert(result, row)
+      end
+      return result
+    end
+
+    -- Step 1: Parse CSV data and validate entries
+    local rawRecords = parseCSV(msg.Data)
+    assert(rawRecords and #rawRecords > 0, 'No transfer entries found in CSV')
+
+    -- Collect valid transfer entries and calculate total
+    local transferEntries = {}
+    local totalQuantity = "0"
+
+    for i, record in ipairs(rawRecords) do
+      local recipient = record[1]
+      local quantity = record[2]
+
+      assert(recipient and quantity, 'Invalid entry at line ' .. i .. ': recipient and quantity required')
+      assert(string.match(quantity, "^%d+$"), 'Invalid quantity format at line ' .. i .. ': must contain only digits')
+      assert(bint.ispos(bint(quantity)), 'Quantity must be greater than 0 at line ' .. i)
+
+      table.insert(transferEntries, {
+        Recipient = recipient,
+        Quantity = quantity
+      })
+
+      totalQuantity = utils.add(totalQuantity, quantity)
+    end
+
+    -- Step 2: Check if sender has enough balance
+    if not Balances[msg.From] then Balances[msg.From] = "0" end
+
+    if not (bint(totalQuantity) <= bint(Balances[msg.From])) then
+      msg.reply({
+        Action = 'Transfer-Error',
+        ['Message-Id'] = msg.Id,
+        Error = 'Insufficient Balance!'
+      })
+      return
+    end
+
+    -- Step 3: Prepare the balance updates
+    local balanceUpdates = {}
+
+    -- Calculate all balance changes
+    for _, entry in ipairs(transferEntries) do
+      local recipient = entry.Recipient
+      local quantity = entry.Quantity
+
+      if not Balances[recipient] then Balances[recipient] = "0" end
+
+      -- Aggregate multiple transfers to the same recipient
+      if not balanceUpdates[recipient] then
+        balanceUpdates[recipient] = utils.add(Balances[recipient], quantity)
+      else
+        balanceUpdates[recipient] = utils.add(balanceUpdates[recipient], quantity)
+      end
+    end
+
+    -- Step 4: Apply the balance changes atomically
+    Balances[msg.From] = utils.subtract(Balances[msg.From], totalQuantity)
+    for recipient, newBalance in pairs(balanceUpdates) do
+      Balances[recipient] = newBalance
+    end
+
+    -- Step 5: Always send a batch debit notice to the sender
+    local batchDebitNotice = {
+      Action = 'Batch-Debit-Notice',
+      Count = tostring(#transferEntries),
+      Total = totalQuantity,
+      ['Batch-Transfer-Init-Id'] = msg.Id,
+      Data = "OK"
+    }
+
+    -- Forward any X- tags to the debit notice
+    for tagName, tagValue in pairs(msg) do
+      if string.sub(tagName, 1, 2) == "X-" then
+        batchDebitNotice[tagName] = tagValue
+      end
+    end
+
+    -- Always send Batch-Debit-Notice to sender
+    msg.reply(batchDebitNotice)
+
+    -- Step 6: Send individual credit notices if Cast tag is not set
+    if not msg.Cast then
+      for _, entry in ipairs(transferEntries) do
+        local recipient = entry.Recipient
+        local quantity = entry.Quantity
+
+        -- Credit-Notice message template, sent to each recipient
+        local creditNotice = {
+          Target = recipient,
+          Action = 'Credit-Notice',
+          Sender = msg.From,
+          Quantity = quantity,
+          ['Batch-Transfer-Init-Id'] = msg.Id,
+          Data = Colors.gray ..
+              "You received " ..
+              Colors.blue .. quantity .. Colors.gray .. " from " .. Colors.green .. msg.From .. Colors.reset
+        }
+
+        -- Forward any X- tags to the credit notices
+        for tagName, tagValue in pairs(msg) do
+          if string.sub(tagName, 1, 2) == "X-" then
+            creditNotice[tagName] = tagValue
+          end
+        end
+
+        -- Send Credit-Notice to recipient
+        Send(creditNotice)
+      end
     end
   end)
 


### PR DESCRIPTION

**Motivation:**

This change introduces a `Batch-Transfer` action to the token blueprint. This functionality is essential for scenarios requiring multiple token transfers from a single sender, such as airdrops, payroll, or reward distributions. Performing these transfers individually is inefficient, incurs higher message overhead, and lacks atomicity guarantees across the entire set of transfers. The `Batch-Transfer` action addresses these issues by allowing multiple transfers to be processed within a single message, ensuring atomicity and reducing memory usage on the token process. 

**Implementation Details:**

*   A new handler is added for messages with `Action = "Batch-Transfer"`.
*   The handler expects a CSV-formatted string in the `msg.Data` field, where each line represents a transfer in the format `recipient_address,quantity`.
*   **CSV Parsing:** A simple, dependency-free CSV parser is included directly within the handler. It splits the input data by newlines and then by commas. This parser is intentionally minimal and assumes valid input adhering strictly to the specified format (no headers, quotes, or escaped commas). It has been tested separately to ensure correctness for its specific use case.
*   **Validation:** The parser validates each entry, ensuring both recipient and quantity are present, the quantity consists only of digits, and the quantity is greater than zero.
*   **Atomic Balance Check & Update:**
    *   The total quantity required for all transfers in the batch is calculated.
    *   The sender's (`msg.From`) balance is checked against this *total* quantity.
    *   If the balance is sufficient, all balance updates (debiting the sender, crediting all recipients) are performed atomically within the handler's execution. If the balance check fails, an error is returned, and *no* balances are changed.
*   **Notifications:**
    *   A single `Batch-Debit-Notice` is *always* sent back to the sender (via `msg.reply`). This notice includes the total number of transfers (`Count`), the total quantity transferred (`Total`), and crucially, a `Batch-Transfer-Init-Id` tag containing the `msg.Id` of the original `Batch-Transfer` message for easy traceability.
    *   **Conditional Credit Notices:** Following the same principle as the standard `Transfer` action, individual `Credit-Notice` messages are sent to each recipient *only if* the initiating `Batch-Transfer` message does *not* include the `Cast = true` tag. If `Cast` is present, these individual notifications are suppressed (recommended behavior). 
    *   Any tags prefixed with `X-` on the original `Batch-Transfer` message are forwarded to both the `Batch-Debit-Notice` and any individual `Credit-Notice` messages sent.

**Caveats:**

*   The CSV parser is basic and expects a strict format (`recipient,quantity`).