### PR TITLE
README: Add instructions for connecting to existing process ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ yarn start
 
 ### Command-line options
 
-You can provide a name for a specific Process, if the Process does not exist aos will spawn the process, then every time you run `aos [name]` it will locate that process and interact with it.
+You can provide a name for a specific Process, if the Process does not exist aos will spawn the process, then every time you run `aos [name]` it will locate that process and interact with it. Alternatively, you can specify a process ID to connect to an existing process with `aos [process-id]`.
 
 ```sh
-aos [name]
+aos [name/process-id]
 ```
 
 #### Flags


### PR DESCRIPTION
The README doesn't make it clear that we are able to connect to existing processes by process ID. I added a quick explanation to the README in this PR.

This is useful information for those who deployed their AO process with tools other than AOS, such as ao-deploy.