### PR TITLE
Normalize Incoming Message Tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ aos.json
 
 .vscode
 .DS_Store
+bun.lock

--- a/process/process.lua
+++ b/process/process.lua
@@ -312,7 +312,7 @@ function process.handle(msg, _)
   
   ao.init(env)
   -- relocate custom tags to root message
-  msg = ao.normalize(msg)
+  msg = process.normalize(msg)
   -- set process id
   ao.id = ao.env.Process.Id
   initializeState(msg, ao.env)
@@ -504,4 +504,27 @@ function process.handle(msg, _)
   end
 end
 
+function process.normalize(msg)
+  -- Normalize tag names to title case
+  if msg.Tags and type(msg.Tags) == "table" then
+    for i, tag in ipairs(msg.Tags) do
+      if tag.name and type(tag.name) == "string" then
+        -- Capitalize first letter
+        local newName = tag.name:gsub("^%l", string.upper)
+        -- Capitalize any letter following a dash
+        newName = newName:gsub("%-(%l)", function(match) return "-" .. string.upper(match) end)
+        -- Capitalize any letter following an underscore
+        newName = newName:gsub("_(%l)", function(match) return "_" .. string.upper(match) end)
+        tag.name = newName
+      end
+    end
+  end
+
+  -- Bring tags to root message
+  ao.normalize(msg)
+
+  return msg
+end
+
 return process
+

--- a/process/process.lua
+++ b/process/process.lua
@@ -63,6 +63,51 @@ ao.spawn = function (module, msg)
   return aospawn(module, msg)
 end
 
+--- Normalizes a message's keys and tags to title case
+-- @function normalize
+-- @tparam {table} msg The message to normalize
+-- @treturn {table} The normalized message
+local function normalizeMsg(msg)
+  -- Helper function to normalize a string
+  local function normalizeString(str)
+    if type(str) ~= "string" then return str end
+    
+    -- Lowercase all letters
+    local result = str:lower()
+    -- Capitalize first letter
+    result = result:gsub("^%l", string.upper)
+    -- Capitalize any letter following a dash
+    result = result:gsub("%-(%l)", function(match) return "-" .. string.upper(match) end)
+    -- Capitalize any letter following an underscore
+    result = result:gsub("_(%l)", function(match) return "_" .. string.upper(match) end)
+    return result
+  end
+
+  -- Normalize keys to title case
+  for key, value in pairs(msg) do
+    local normalizedKey = normalizeString(key)
+    -- Only add to normalizedKeys if the key changed during normalization
+    if normalizedKey ~= key then
+      msg[key] = nil
+      msg[normalizedKey] = value
+    end
+  end
+
+  -- Normalize tag names to title case
+  if msg.Tags and type(msg.Tags) == "table" then
+    for i, tag in ipairs(msg.Tags) do
+      if tag.name and type(tag.name) == "string" then
+        tag.name = normalizeString(tag.name)
+      end
+    end
+  end
+
+  -- Bring tags to root message
+  ao.normalize(msg)
+
+  return msg
+end
+
 --- Remove the last three lines from a string
 -- @lfunction removeLastThreeLines
 -- @tparam {string} input The string to remove the last three lines from
@@ -312,7 +357,7 @@ function process.handle(msg, _)
   
   ao.init(env)
   -- relocate custom tags to root message
-  msg = process.normalize(msg)
+  msg = normalizeMsg(msg)
   -- set process id
   ao.id = ao.env.Process.Id
   initializeState(msg, ao.env)
@@ -502,48 +547,6 @@ function process.handle(msg, _)
     ao.Nonce = msg.Nonce
     return response
   end
-end
-
-function process.normalize(msg)
-  -- Helper function to normalize a string
-  local function normalizeString(str)
-    if type(str) ~= "string" then return str end
-    
-    -- Lowercase all letters
-    local result = str:lower()
-    
-    -- Capitalize first letter
-    result = result:gsub("^%l", string.upper)
-    -- Capitalize any letter following a dash
-    result = result:gsub("%-(%l)", function(match) return "-" .. string.upper(match) end)
-    -- Capitalize any letter following an underscore
-    result = result:gsub("_(%l)", function(match) return "_" .. string.upper(match) end)
-    return result
-  end
-
-  -- Normalize keys to title case
-  for key, value in pairs(msg) do
-    local normalizedKey = normalizeString(key)
-    -- Only add to normalizedKeys if the key changed during normalization
-    if normalizedKey ~= key then
-      msg[key] = nil
-      msg[normalizedKey] = value
-    end
-  end
-
-  -- Normalize tag names to title case
-  if msg.Tags and type(msg.Tags) == "table" then
-    for i, tag in ipairs(msg.Tags) do
-      if tag.name and type(tag.name) == "string" then
-        tag.name = normalizeString(tag.name)
-      end
-    end
-  end
-
-  -- Bring tags to root message
-  ao.normalize(msg)
-
-  return msg
 end
 
 return process

--- a/process/process.lua
+++ b/process/process.lua
@@ -508,8 +508,12 @@ function process.normalize(msg)
   -- Helper function to normalize a string
   local function normalizeString(str)
     if type(str) ~= "string" then return str end
+    
+    -- Lowercase all letters
+    local result = str:lower()
+    
     -- Capitalize first letter
-    local result = str:gsub("^%l", string.upper)
+    result = result:gsub("^%l", string.upper)
     -- Capitalize any letter following a dash
     result = result:gsub("%-(%l)", function(match) return "-" .. string.upper(match) end)
     -- Capitalize any letter following an underscore
@@ -517,7 +521,7 @@ function process.normalize(msg)
     return result
   end
 
-  -- Create a table of normalized keys
+  -- Normalize keys to title case
   for key, value in pairs(msg) do
     local normalizedKey = normalizeString(key)
     -- Only add to normalizedKeys if the key changed during normalization

--- a/process/process.lua
+++ b/process/process.lua
@@ -505,17 +505,33 @@ function process.handle(msg, _)
 end
 
 function process.normalize(msg)
+  -- Helper function to normalize a string
+  local function normalizeString(str)
+    if type(str) ~= "string" then return str end
+    -- Capitalize first letter
+    local result = str:gsub("^%l", string.upper)
+    -- Capitalize any letter following a dash
+    result = result:gsub("%-(%l)", function(match) return "-" .. string.upper(match) end)
+    -- Capitalize any letter following an underscore
+    result = result:gsub("_(%l)", function(match) return "_" .. string.upper(match) end)
+    return result
+  end
+
+  -- Create a table of normalized keys
+  for key, value in pairs(msg) do
+    local normalizedKey = normalizeString(key)
+    -- Only add to normalizedKeys if the key changed during normalization
+    if normalizedKey ~= key then
+      msg[key] = nil
+      msg[normalizedKey] = value
+    end
+  end
+
   -- Normalize tag names to title case
   if msg.Tags and type(msg.Tags) == "table" then
     for i, tag in ipairs(msg.Tags) do
       if tag.name and type(tag.name) == "string" then
-        -- Capitalize first letter
-        local newName = tag.name:gsub("^%l", string.upper)
-        -- Capitalize any letter following a dash
-        newName = newName:gsub("%-(%l)", function(match) return "-" .. string.upper(match) end)
-        -- Capitalize any letter following an underscore
-        newName = newName:gsub("_(%l)", function(match) return "_" .. string.upper(match) end)
-        tag.name = newName
+        tag.name = normalizeString(tag.name)
       end
     end
   end

--- a/process/test/normalized-message.test.js
+++ b/process/test/normalized-message.test.js
@@ -1,0 +1,101 @@
+import { test } from 'node:test'
+import * as assert from 'node:assert'
+import AoLoader from '@permaweb/ao-loader'
+import fs from 'fs'
+
+const wasm = fs.readFileSync('./process.wasm')
+const options = { format: "wasm64-unknown-emscripten-draft_2024_02_15" }
+
+const env = {
+  Process: {
+    Id: 'AOS',
+    Owner: 'FOOBAR',
+    Tags: [
+      { name: 'Name', value: 'Thomas' }
+    ]
+  }
+}
+
+async function init(handle) {
+  const {Memory} = await handle(null, {
+    Target: 'AOS',
+    From: 'FOOBAR',
+    Owner: 'FOOBAR',
+    'Block-Height': '999',
+    Id: 'AOS',
+    Module: 'WOOPAWOOPA',
+    Tags: [
+      { name: 'Name', value: 'Thomas' }
+    ]
+  }, env)
+  return Memory
+}
+
+test('message normalization - lowercase to uppercase', async () => {
+  const handle = await AoLoader(wasm, options)
+  const start = await init(handle)
+  
+  // Create an evaluation message that will inspect an incoming message
+  const evalMsg = {
+    Target: 'AOS',
+    From: 'FOOBAR',
+    Owner: 'FOOBAR',
+    ['Block-Height']: "1000",
+    Id: "1234xyxfoo",
+    Module: "WOOPAWOOPA",
+    Tags: [
+      { name: 'Action', value: 'Eval' }
+    ],
+    Data: `
+Handlers.add("inspect-normalized", 
+  function (msg)
+    return msg.Tags["type"] == "test-event" or msg.Tags["Type"] == "test-event"
+  end, 
+  function (msg) 
+    -- Print normalized message keys
+    print("Type: " .. (msg.Tags["Type"] or "nil"))
+    print("Data-Protocol: " .. (msg.Tags["Data-Protocol"] or "nil"))
+    print("Message: " .. (msg.Tags["Message"] or "nil"))
+    
+    -- Also verify lowercase keys are not accessible
+    print("type (lowercase): " .. (msg.Tags["type"] or "nil"))
+    
+    -- Return true if keys were normalized properly
+    return msg.Tags["Type"] == "test-event" and 
+           msg.Tags["Data-Protocol"] == "https://example.com/protocol" and
+           msg.Tags["Message"] == "Hello, world!"
+  end
+)
+    `
+  }
+  
+  // Load the handler
+  const { Memory } = await handle(start, evalMsg, env)
+  
+  // Test message with lowercase keys
+  const testMsg = {
+    Target: 'AOS',
+    From: 'FRED',
+    Owner: 'FRED',
+    Tags: [
+      { name: 'type', value: 'test-event' },
+      { name: 'data-protocol', value: 'https://example.com/protocol' },
+      { name: 'message', value: 'Hello, world!' }
+    ],
+    Data: 'Test normalized message'
+  }
+  
+  const { Output } = await handle(Memory, testMsg, env)
+  
+  console.log(`OUTPUT:`)
+  console.log(Output)
+  
+  // Check if output contains the normalized values
+  assert.ok(Output.data.includes('Type: test-event'))
+  assert.ok(Output.data.includes('Data-Protocol: https://example.com/protocol'))
+  assert.ok(Output.data.includes('Message: Hello, world!'))
+
+  
+  // The lowercase keys should be inaccessible after normalization
+//   assert.ok(!Output.data.includes('type (lowercase): nil'))
+}) 

--- a/process/test/normalized-message.test.js
+++ b/process/test/normalized-message.test.js
@@ -53,8 +53,6 @@ Handlers.add("inspect-normalized",
   end, 
   function (msg) 
     -- Print normalized message keys
-    print("TAGS:")
-    print(msg.Tags)
     print("Type: " .. (msg.Tags["Type"] or "nil"))
     print("Data-Protocol: " .. (msg.Tags["Data-Protocol"] or "nil"))
     print("Message: " .. (msg.Tags["Message"] or "nil"))
@@ -88,15 +86,11 @@ Handlers.add("inspect-normalized",
   
   const { Output } = await handle(Memory, testMsg, env)
   
-  console.log(`OUTPUT:`)
-  console.log(Output)
-  console.log(`MESSAGES:`)
   
   // Check if output contains the normalized values
   assert.ok(Output.data.includes('Type: test-event'))
   assert.ok(Output.data.includes('Data-Protocol: https://example.com/protocol'))
   assert.ok(Output.data.includes('Message: Hello, world!'))
   assert.ok(Output.data.includes('Action: test-action'))
-
 
 }) 

--- a/process/test/normalized-message.test.js
+++ b/process/test/normalized-message.test.js
@@ -31,7 +31,7 @@ async function init(handle) {
   return Memory
 }
 
-test('message normalization - lowercase to uppercase', async () => {
+test('message normalization - to title case', async () => {
   const handle = await AoLoader(wasm, options)
   const start = await init(handle)
   
@@ -53,12 +53,12 @@ Handlers.add("inspect-normalized",
   end, 
   function (msg) 
     -- Print normalized message keys
+    print("TAGS:")
+    print(msg.Tags)
     print("Type: " .. (msg.Tags["Type"] or "nil"))
     print("Data-Protocol: " .. (msg.Tags["Data-Protocol"] or "nil"))
     print("Message: " .. (msg.Tags["Message"] or "nil"))
-    
-    -- Also verify lowercase keys are not accessible
-    print("type (lowercase): " .. (msg.Tags["type"] or "nil"))
+    print("Action: " .. (msg.Tags["Action"] or "nil"))
     
     -- Return true if keys were normalized properly
     return msg.Tags["Type"] == "test-event" and 
@@ -79,8 +79,9 @@ Handlers.add("inspect-normalized",
     Owner: 'FRED',
     Tags: [
       { name: 'type', value: 'test-event' },
-      { name: 'data-protocol', value: 'https://example.com/protocol' },
-      { name: 'message', value: 'Hello, world!' }
+      { name: 'data-PROTOCOL', value: 'https://example.com/protocol' },
+      { name: 'MESSAGE', value: 'Hello, world!' },
+      { name: 'action', value: 'test-action' }
     ],
     Data: 'Test normalized message'
   }
@@ -89,13 +90,13 @@ Handlers.add("inspect-normalized",
   
   console.log(`OUTPUT:`)
   console.log(Output)
+  console.log(`MESSAGES:`)
   
   // Check if output contains the normalized values
   assert.ok(Output.data.includes('Type: test-event'))
   assert.ok(Output.data.includes('Data-Protocol: https://example.com/protocol'))
   assert.ok(Output.data.includes('Message: Hello, world!'))
+  assert.ok(Output.data.includes('Action: test-action'))
 
-  
-  // The lowercase keys should be inaccessible after normalization
-//   assert.ok(!Output.data.includes('type (lowercase): nil'))
+
 }) 


### PR DESCRIPTION

# Add Message Normalization for Consistent Key Formatting

## Overview
Introduces enhanced message normalization to ensure consistent key and tag name formatting across the AO network by converting them to title case.

## Changes
- **Added `normalizeMsg()` function** that normalizes message keys and tag names to title case
  - Handles dashes and underscores (e.g., `data-protocol` → `Data-Protocol`)
  - Replaces `ao.normalize(msg)` in main handler while preserving existing functionality
- **Added tests for normalized message keys** (`process/test/normalized-message.test.js`)

## Example
### `action` -> `Action`
![image](https://github.com/user-attachments/assets/1e26d994-1810-4f72-be6f-94fd870591d0)
### `data-protocol` -> `Data-Protocol`
![image](https://github.com/user-attachments/assets/28106c93-c3b3-4272-abf1-d74a7eb565cc)
